### PR TITLE
RestrictingCodeExecutable class

### DIFF
--- a/codetools/execution/executing_context.py
+++ b/codetools/execution/executing_context.py
@@ -11,7 +11,6 @@ from codetools.contexts.i_context import IContext, IListenableContext
 from interfaces import IExecutable, IExecutingContext
 
 
-
 class CodeExecutable(HasTraits):
     """ Simple IExecutable that plainly executes a piece of code.
     """
@@ -28,7 +27,7 @@ class CodeExecutable(HasTraits):
             globals = {}
 
         exec self.code in globals, icontext
-
+        return inputs, outputs
 
 
 class ExecutingContext(DataContext):
@@ -48,7 +47,6 @@ class ExecutingContext(DataContext):
 
     # When execution is deferred, we need to keep a list of these events.
     _deferred_execution_names = List(Str, transient=True)
-
 
     def execute_for_names(self, names):
         """ Possibly execute for a set of names which have been changed.
@@ -73,7 +71,6 @@ class ExecutingContext(DataContext):
         self.executable.execute(self.subcontext, inputs=affected_names)
         self.subcontext.defer_events = False
 
-
     #### IContext interface ####################################################
 
     def __setitem__(self, key, value):
@@ -83,7 +80,6 @@ class ExecutingContext(DataContext):
     def __delitem__(self, key):
         del self.subcontext[key]
         self.execute_for_names([key])
-
 
     #### Trait Event Handlers ##################################################
 
@@ -108,5 +104,3 @@ class ExecutingContext(DataContext):
 
         self._fire_event(added=event.added, removed=event.removed,
             modified=event.modified, context=event.context)
-
-

--- a/codetools/execution/executing_context.py
+++ b/codetools/execution/executing_context.py
@@ -23,9 +23,9 @@ class CodeExecutable(HasTraits):
     def execute(self, context, globals=None, inputs=None, outputs=None):
         icontext = adapt(context, IContext)
 
-        if not inputs:
+        if inputs is not None:
             inputs = []
-        if not outputs:
+        if outputs is not None:
             outputs = []
 
         if globals is None:

--- a/codetools/execution/executing_context.py
+++ b/codetools/execution/executing_context.py
@@ -23,6 +23,11 @@ class CodeExecutable(HasTraits):
     def execute(self, context, globals=None, inputs=None, outputs=None):
         icontext = adapt(context, IContext)
 
+        if not inputs:
+            inputs = []
+        if not outputs:
+            outputs = []
+
         if globals is None:
             globals = {}
 

--- a/codetools/execution/executing_context.py
+++ b/codetools/execution/executing_context.py
@@ -27,7 +27,7 @@ class CodeExecutable(HasTraits):
             globals = {}
 
         exec self.code in globals, icontext
-        return inputs, outputs
+        return set(inputs), set(outputs)
 
 
 class ExecutingContext(DataContext):

--- a/codetools/execution/executing_context.py
+++ b/codetools/execution/executing_context.py
@@ -23,9 +23,9 @@ class CodeExecutable(HasTraits):
     def execute(self, context, globals=None, inputs=None, outputs=None):
         icontext = adapt(context, IContext)
 
-        if inputs is not None:
+        if inputs is None:
             inputs = []
-        if outputs is not None:
+        if outputs is None:
             outputs = []
 
         if globals is None:

--- a/codetools/execution/interfaces.py
+++ b/codetools/execution/interfaces.py
@@ -25,6 +25,14 @@ class IExecutable(Interface):
         outputs : list of str, optional
             Names of output variables. These are used to restrict the execution
             to portions of the code that affect the outputs.
+
+        Returns
+        -------
+        inputs : list of str
+            The inputs of the restricted block
+        outputs : list of str
+            The outputs of the restricted block
+
         """
 
 
@@ -41,5 +49,3 @@ class IExecutingContext(IListenableContext):
 
     # Whether to trigger recomputation on 'items_modified' immediately or not.
     defer_execution = Bool(False)
-
-

--- a/codetools/execution/interfaces.py
+++ b/codetools/execution/interfaces.py
@@ -28,9 +28,9 @@ class IExecutable(Interface):
 
         Returns
         -------
-        inputs : list of str
+        inputs : set of str
             The inputs of the restricted block
-        outputs : list of str
+        outputs : set of str
             The outputs of the restricted block
 
         """

--- a/codetools/execution/restricting_code_executable.py
+++ b/codetools/execution/restricting_code_executable.py
@@ -1,5 +1,5 @@
 from traits.api import (HasStrictTraits, Str, implements, Instance,
-        on_trait_change)
+        Property)
 from traits.protocols.api import adapt
 from codetools.blocks.block import Block
 from codetools.execution.interfaces import IExecutable
@@ -14,8 +14,11 @@ class RestrictingCodeExecutable(HasStrictTraits):
 
     implements(IExecutable)
 
+    # The code to be executed. Read/Write
+    code = Property(depends_on='_code')
+
     # The code to execute.
-    code = Str('pass')
+    _code = Str('pass')
 
     # The block that handles code restriction
     _block = Instance(Block)
@@ -54,7 +57,7 @@ class RestrictingCodeExecutable(HasStrictTraits):
         filtered_outputs = set(outputs).intersection(in_and_out)
 
         #If called with no inputs or outputs the full block executes
-        if inputs or outputs:
+        if filtered_inputs or filtered_outputs:
             block = self._block.restrict(inputs=filtered_inputs,
                     outputs=filtered_outputs)
         else:
@@ -62,6 +65,9 @@ class RestrictingCodeExecutable(HasStrictTraits):
         block.execute(icontext, global_context=globals)
         return block.inputs, block.outputs
 
-    @on_trait_change('code')
-    def _code_changed(self, new):
+    def _set_code(self, new):
         self._block = Block(new)
+        self._code = new
+
+    def _get_code(self, new):
+        self._code = new

--- a/codetools/execution/restricting_code_executable.py
+++ b/codetools/execution/restricting_code_executable.py
@@ -70,4 +70,4 @@ class RestrictingCodeExecutable(HasStrictTraits):
         self._code = new
 
     def _get_code(self, new):
-        self._code = new
+        return self._code

--- a/codetools/execution/restricting_code_executable.py
+++ b/codetools/execution/restricting_code_executable.py
@@ -15,24 +15,10 @@ class RestrictingCodeExecutable(HasStrictTraits):
     implements(IExecutable)
 
     # The code to execute.
-    code = Str
+    code = Str('Pass')
 
     # The block that handles code restriction
     _block = Instance(Block)
-
-    def __init__(self, code=None, **kwargs):
-        """
-        Parameters
-        ----------
-        code: String, required
-
-        """
-        if code is None:
-            raise ValueError('%s must be initialized with code' % \
-                    self.__class__)
-        super(RestrictingCodeExecutable, self).__init__(**kwargs)
-        self.code = code
-        self._block = Block(code)
 
     def execute(self, context, globals=None, inputs=None, outputs=None):
         """ Execute code in context, optionally restricting on inputs or
@@ -70,6 +56,6 @@ class RestrictingCodeExecutable(HasStrictTraits):
         block.execute(icontext, global_context=globals)
         return block.inputs, block.outputs
 
-    @on_trait_change('code', post_init=True)
+    @on_trait_change('code')
     def _code_changed(self, new):
         self._block = Block(new)

--- a/codetools/execution/restricting_code_executable.py
+++ b/codetools/execution/restricting_code_executable.py
@@ -1,4 +1,5 @@
-from traits.api import HasStrictTraits, Str, implements, Instance
+from traits.api import (HasStrictTraits, Str, implements, Instance,
+        on_trait_change)
 from traits.protocols.api import adapt
 from codetools.blocks.block import Block
 from codetools.execution.interfaces import IExecutable
@@ -17,7 +18,7 @@ class RestrictingCodeExecutable(HasStrictTraits):
     code = Str
 
     # The block that handles code restriction
-    block = Instance(Block)
+    _block = Instance(Block)
 
     def __init__(self, code=None, **kwargs):
         """
@@ -31,7 +32,7 @@ class RestrictingCodeExecutable(HasStrictTraits):
                     self.__class__)
         super(RestrictingCodeExecutable, self).__init__(**kwargs)
         self.code = code
-        self.block = Block(code)
+        self._block = Block(code)
 
     def execute(self, context, globals=None, inputs=None, outputs=None):
         """ Execute code in context, optionally restricting on inputs or
@@ -56,7 +57,11 @@ class RestrictingCodeExecutable(HasStrictTraits):
 
         #If called with no inputs or outputs the full block executes
         if inputs or outputs:
-            block = self.block.restrict(inputs=inputs, outputs=outputs)
+            block = self._block.restrict(inputs=inputs, outputs=outputs)
         else:
-            block = self.block
+            block = self._block
         block.execute(icontext, global_context=globals)
+
+    @on_trait_change('code', post_init=True)
+    def _code_changed(self, new):
+        self._block = Block(new)

--- a/codetools/execution/restricting_code_executable.py
+++ b/codetools/execution/restricting_code_executable.py
@@ -45,6 +45,13 @@ class RestrictingCodeExecutable(HasStrictTraits):
         inputs : List of strings, options
         outputs : List of strings, optional
 
+        Returns
+        -------
+        inputs : set
+            the inputs to the restricted block
+        outpus : set
+            the outputs of the restricted block
+
         """
         icontext = adapt(context, IContext)
 
@@ -61,6 +68,7 @@ class RestrictingCodeExecutable(HasStrictTraits):
         else:
             block = self._block
         block.execute(icontext, global_context=globals)
+        return block.inputs, block.outputs
 
     @on_trait_change('code', post_init=True)
     def _code_changed(self, new):

--- a/codetools/execution/restricting_code_executable.py
+++ b/codetools/execution/restricting_code_executable.py
@@ -44,13 +44,19 @@ class RestrictingCodeExecutable(HasStrictTraits):
         if globals is None:
             globals = {}
         if inputs is None:
-            inputs = []
+            inputs = set()
         if outputs is None:
-            outputs = []
+            outputs = set()
+
+        # filter out and inputs or outputs that are not in the code
+        in_and_out = self._block.inputs.union(self._block.outputs)
+        filtered_inputs = set(inputs).intersection(in_and_out)
+        filtered_outputs = set(outputs).intersection(in_and_out)
 
         #If called with no inputs or outputs the full block executes
         if inputs or outputs:
-            block = self._block.restrict(inputs=inputs, outputs=outputs)
+            block = self._block.restrict(inputs=filtered_inputs,
+                    outputs=filtered_outputs)
         else:
             block = self._block
         block.execute(icontext, global_context=globals)

--- a/codetools/execution/restricting_code_executable.py
+++ b/codetools/execution/restricting_code_executable.py
@@ -15,7 +15,7 @@ class RestrictingCodeExecutable(HasStrictTraits):
     implements(IExecutable)
 
     # The code to execute.
-    code = Str('Pass')
+    code = Str('pass')
 
     # The block that handles code restriction
     _block = Instance(Block)

--- a/codetools/execution/restricting_code_executable.py
+++ b/codetools/execution/restricting_code_executable.py
@@ -1,0 +1,62 @@
+from traits.api import HasStrictTraits, Str, implements, Instance
+from traits.protocols.api import adapt
+from codetools.blocks.block import Block
+from codetools.execution.interfaces import IExecutable
+from codetools.contexts.i_context import IContext
+
+
+class RestrictingCodeExecutable(HasStrictTraits):
+    """ IExecutable that executes a piece of code, optionally restricting
+    beforehand
+
+    """
+
+    implements(IExecutable)
+
+    # The code to execute.
+    code = Str
+
+    # The block that handles code restriction
+    block = Instance(Block)
+
+    def __init__(self, code=None, **kwargs):
+        """
+        Parameters
+        ----------
+        code: String, required
+
+        """
+        if code is None:
+            raise ValueError('%s must be initialized with code' % \
+                    self.__class__)
+        super(RestrictingCodeExecutable, self).__init__(**kwargs)
+        self.code = code
+        self.block = Block(code)
+
+    def execute(self, context, globals=None, inputs=None, outputs=None):
+        """ Execute code in context, optionally restricting on inputs or
+        outputs if supplied
+
+        Parameters
+        ----------
+        context : Dict-like
+        globals : Dict-like, optional
+        inputs : List of strings, options
+        outputs : List of strings, optional
+
+        """
+        icontext = adapt(context, IContext)
+
+        if globals is None:
+            globals = {}
+        if inputs is None:
+            inputs = []
+        if outputs is None:
+            outputs = []
+
+        #If called with no inputs or outputs the full block executes
+        if inputs or outputs:
+            block = self.block.restrict(inputs=inputs, outputs=outputs)
+        else:
+            block = self.block
+        block.execute(icontext, global_context=globals)

--- a/codetools/execution/tests/test_restricting_code_executable.py
+++ b/codetools/execution/tests/test_restricting_code_executable.py
@@ -4,15 +4,13 @@ from codetools.execution.executing_context import ExecutingContext
 from codetools.execution.restricting_code_executable import (
         RestrictingCodeExecutable)
 
-from fei.testing.test_assistant import TestAssistant
-
 CODE = """aa = 2 * a
 bb = 2 * b
 c = a + b + aa + bb
 """
 
 
-class TestRestrictingCodeExecutable(unittest.TestCase, TestAssistant):
+class TestRestrictingCodeExecutable(unittest.TestCase):
 
     def setUp(self):
         self.restricting_exec = RestrictingCodeExecutable(code=CODE)

--- a/codetools/execution/tests/test_restricting_code_executable.py
+++ b/codetools/execution/tests/test_restricting_code_executable.py
@@ -49,9 +49,12 @@ class TestRestrictingCodeExecutable(unittest.TestCase, TestAssistant):
     def test_api_compatibility(self):
         executing_context = ExecutingContext(executable=self.restricting_exec,
                 subcontext=self.context)
+        self.assertIs(self.context, executing_context.subcontext.subcontext)
         executing_context.execute_for_names(None)
         with self.assertTraitChanges(executing_context, 'items_modified'):
-            executing_context['a'] = 5
+            executing_context['bb'] = 5
+        expected_context = {'a': 1, 'b': 10, 'aa': 2, 'bb': 5, 'c': 18}
+        self.assertEqual(self.context, expected_context)
 
 
 if __name__ == '__main__':

--- a/codetools/execution/tests/test_restricting_code_executable.py
+++ b/codetools/execution/tests/test_restricting_code_executable.py
@@ -1,0 +1,58 @@
+import unittest
+
+from codetools.execution.executing_context import ExecutingContext
+
+from fei.testing.test_assistant import TestAssistant
+from fei.edx.model.block_pipeline.restricting_code_executable import (
+        RestrictingCodeExecutable)
+
+CODE = """aa = 2 * a
+bb = 2 * b
+c = a + b + aa + bb
+"""
+
+
+class TestRestrictingCodeExecutable(unittest.TestCase, TestAssistant):
+
+    def setUp(self):
+        self.restricting_exec = RestrictingCodeExecutable(code=CODE)
+        self.context = {'a': 1, 'b': 10}
+
+    def test_execute(self):
+        self.restricting_exec.execute(self.context)
+        expected_context = {'a': 1, 'b': 10, 'aa': 2, 'bb': 20, 'c': 33}
+        self.assertEqual(self.context, expected_context)
+
+    def test_restrict_on_inputs(self):
+        context = {'a': 1, 'b': 10, 'bb': 100}
+        self.restricting_exec.execute(context, inputs=['a'])
+        #Check if `bb` was incorrectly overwritten by the codeblock
+        self.assertEqual(context['bb'], 100)
+
+    def test_restrict_on_outputs(self):
+        context = {'b': 10, 'bb': 100}
+        self.restricting_exec.execute(context, outputs=['bb'])
+        self.assertEqual(context, {'b': 10, 'bb': 20})
+
+    def test_code_exists(self):
+        self.assertEqual(self.restricting_exec.code, CODE)
+        self.assertEqual(self.restricting_exec.block.codestring, CODE)
+
+    def test_init_with_code_error_fails(self):
+        with self.assertRaises(SyntaxError):
+            restricting_exec = RestrictingCodeExecutable(".,.")
+
+    def test_init_without_code_fails(self):
+        with self.assertRaises(ValueError):
+            restricting_exec = RestrictingCodeExecutable()
+
+    def test_api_compatibility(self):
+        executing_context = ExecutingContext(executable=self.restricting_exec,
+                subcontext=self.context)
+        executing_context.execute_for_names(None)
+        with self.assertTraitChanges(executing_context, 'items_modified'):
+            executing_context['a'] = 5
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/codetools/execution/tests/test_restricting_code_executable.py
+++ b/codetools/execution/tests/test_restricting_code_executable.py
@@ -1,10 +1,10 @@
 import unittest
 
 from codetools.execution.executing_context import ExecutingContext
+from codetools.execution.restricting_code_executable import (
+        RestrictingCodeExecutable)
 
 from fei.testing.test_assistant import TestAssistant
-from fei.edx.model.block_pipeline.restricting_code_executable import (
-        RestrictingCodeExecutable)
 
 CODE = """aa = 2 * a
 bb = 2 * b
@@ -36,15 +36,19 @@ class TestRestrictingCodeExecutable(unittest.TestCase, TestAssistant):
 
     def test_code_exists(self):
         self.assertEqual(self.restricting_exec.code, CODE)
-        self.assertEqual(self.restricting_exec.block.codestring, CODE)
+        self.assertEqual(self.restricting_exec._block.codestring, CODE)
 
     def test_init_with_code_error_fails(self):
         with self.assertRaises(SyntaxError):
-            restricting_exec = RestrictingCodeExecutable(".,.")
+            restricting_exec = RestrictingCodeExecutable(code=".,.")
 
     def test_init_without_code_fails(self):
         with self.assertRaises(ValueError):
             restricting_exec = RestrictingCodeExecutable()
+
+    def test_code_changing(self):
+        with self.assertTraitChanges(self.restricting_exec, '_block'):
+            self.restricting_exec.code = "c = a + b"
 
     def test_api_compatibility(self):
         executing_context = ExecutingContext(executable=self.restricting_exec,

--- a/codetools/execution/tests/test_restricting_code_executable.py
+++ b/codetools/execution/tests/test_restricting_code_executable.py
@@ -38,14 +38,6 @@ class TestRestrictingCodeExecutable(unittest.TestCase, TestAssistant):
         self.assertEqual(self.restricting_exec.code, CODE)
         self.assertEqual(self.restricting_exec._block.codestring, CODE)
 
-    def test_init_with_code_error_fails(self):
-        with self.assertRaises(SyntaxError):
-            restricting_exec = RestrictingCodeExecutable(code=".,.")
-
-    def test_init_without_code_fails(self):
-        with self.assertRaises(ValueError):
-            restricting_exec = RestrictingCodeExecutable()
-
     def test_code_changing(self):
         with self.assertTraitChanges(self.restricting_exec, '_block'):
             self.restricting_exec.code = "c = a + b"

--- a/codetools/execution/tests/test_restricting_code_executable.py
+++ b/codetools/execution/tests/test_restricting_code_executable.py
@@ -49,11 +49,11 @@ class TestRestrictingCodeExecutable(unittest.TestCase):
         executing_context.execute_for_names(None)
         executing_context.on_trait_change(self._change_detect, 'items_modified')
         executing_context['bb'] = 5
-        self.assertEqual(self.events, ['fired'])
+        self.assertEqual(self.events, ['fired', 'fired'])
         expected_context = {'a': 1, 'b': 10, 'aa': 2, 'bb': 5, 'c': 18}
         self.assertEqual(self.context, expected_context)
 
-    def _change_detect(self):
+    def _change_detect(self, new):
         self.events.append('fired')
 
 


### PR DESCRIPTION
This PR adds a new `RestrictingCodeExecutable` class that implements the IExecutable interface.

The class has an `execute()` method that executes the code in a block, optionally restricting on inputs or outputs.
