### PR TITLE
Make IListenable, IPersistable, IExecuting, and IRestricted stand-alone interfaces.

### DIFF
--- a/codetools/contexts/data_context.py
+++ b/codetools/contexts/data_context.py
@@ -22,7 +22,7 @@ from traits.api import (Bool, Dict, HasTraits, Str, Supports,
                         adapt, provides, on_trait_change)
 
 from .i_context import (IContext, ICheckpointable, IListenableContext,
-                       IPersistableContext, IRestrictedContext)
+                        IPersistableContext, IRestrictedContext)
 from .items_modified_event import ItemsModifiedEvent, ItemsModified
 
 # This is copied from numerical_modeling.numeric_context.constants
@@ -231,8 +231,8 @@ class PersistableMixin(HasTraits):
 
 
 
-@provides(ICheckpointable, IListenableContext, IPersistableContext,
-            IRestrictedContext)
+@provides(ICheckpointable, IContext, IListenableContext, IPersistableContext,
+          IRestrictedContext)
 class DataContext(ListenableMixin, PersistableMixin, DictMixin):
     """ A simple context which fires events.
     """
@@ -244,7 +244,7 @@ class DataContext(ListenableMixin, PersistableMixin, DictMixin):
     subcontext = Supports(IContext, factory=dict)
 
 
-    #### IContext interface ####################################################
+    #### IContext interface ###################################################
 
     def __contains__(self, key):
         return key in self.subcontext
@@ -310,7 +310,7 @@ class DataContext(ListenableMixin, PersistableMixin, DictMixin):
             return cls_cmp
         return DictMixin.__cmp__(self, other)
 
-    #### IRestrictedContext interface ##########################################
+    #### IRestrictedContext interface #########################################
 
     def allows(self, value, name=None):
         """ Determines whether this value is allowed in this context. Only

--- a/codetools/contexts/hdf5_context.py
+++ b/codetools/contexts/hdf5_context.py
@@ -7,12 +7,13 @@
 #
 from __future__ import absolute_import
 
-from traits.api import HasTraits, List, Str, Property, Any, provides
-from codetools.contexts.api import IRestrictedContext
+from codetools.contexts.i_context import IContext, IRestrictedContext
+from traits.api import HasTraits, List, Str, Any, provides
 
 import tables
 
-@provides(IRestrictedContext)
+
+@provides(IContext, IRestrictedContext)
 class Hdf5Context(HasTraits):
     """ Provide a "context" (partial dictionary interface) into an HDF5
         file.  It allows multiple paths, specified by the path list, within

--- a/codetools/contexts/i_context.py
+++ b/codetools/contexts/i_context.py
@@ -110,7 +110,7 @@ def defer_events(data_context):
 defer_events.context_counts = {}
 
 
-class IListenableContext(IContext):
+class IListenableContext(Interface):
     """ A context that fires events when it is modified.
     """
 
@@ -131,7 +131,7 @@ class IListenableContext(IContext):
         raise NotImplementedError
 
 
-class IRestrictedContext(IContext):
+class IRestrictedContext(Interface):
     """ A context that has certain restrictions on the values it is allowed to
     contain.
     """
@@ -155,7 +155,7 @@ class IRestrictedContext(IContext):
         """
 
 
-class IPersistableContext(IContext):
+class IPersistableContext(Interface):
     """ Add loading and saving to the interface.
     """
 

--- a/codetools/contexts/multi_context.py
+++ b/codetools/contexts/multi_context.py
@@ -14,17 +14,17 @@ from __future__ import absolute_import
 from itertools import chain
 from UserDict import DictMixin
 
-from traits.api import (Bool, List, Str, Undefined, Supports,
-    adapt, provides, on_trait_change)
+from traits.api import (Bool, List, Str, Undefined, Supports, adapt, provides,
+                        on_trait_change)
 
 from .data_context import DataContext, ListenableMixin, PersistableMixin
-from .i_context import (ICheckpointable, IListenableContext,
-    IPersistableContext, IRestrictedContext)
+from .i_context import (ICheckpointable, IContext, IListenableContext,
+                        IPersistableContext, IRestrictedContext)
 from .utils import safe_repr
 
 
-@provides(ICheckpointable, IListenableContext, IPersistableContext,
-            IRestrictedContext)
+@provides(ICheckpointable, IContext, IListenableContext, IPersistableContext,
+          IRestrictedContext)
 class MultiContext(ListenableMixin, PersistableMixin, DictMixin):
     """ Wrap several subcontexts.
     """

--- a/codetools/execution/executing_context.py
+++ b/codetools/execution/executing_context.py
@@ -10,8 +10,8 @@ namespace.
 """
 from __future__ import absolute_import
 
-from traits.api import (Bool, HasTraits, List, Str, Supports,
-    Undefined, adapt, provides, on_trait_change)
+from traits.api import (Bool, HasTraits, List, Str, Supports, Undefined,
+                        adapt, provides, on_trait_change)
 
 from codetools.contexts.data_context import DataContext
 from codetools.contexts.i_context import IContext, IListenableContext
@@ -41,7 +41,7 @@ class CodeExecutable(HasTraits):
         return set(inputs), set(outputs)
 
 
-@provides(IExecutingContext)
+@provides(IContext, IExecutingContext, IListenableContext)
 class ExecutingContext(DataContext):
     """ A context which will execute code in response to changes in its
     namespace.

--- a/codetools/execution/interfaces.py
+++ b/codetools/execution/interfaces.py
@@ -44,7 +44,7 @@ class IExecutable(Interface):
         """
 
 
-class IExecutingContext(IListenableContext):
+class IExecutingContext(Interface):
     """ A context that manages the execution of a piece of code for another
     context.
     """


### PR DESCRIPTION
Update the rest of the library to match the changes.

Having independent interfaces is important to play well with adaptation.
Specifically, here we have adapters from IContext to IListenable,
IPersistable, IExecuting, and IRestricted. If we allow them to be
subclasses of IContext, each adapter can be applied to the result of
adaptation, causing an explosion of aadptation paths.
