### PR TITLE
Introduce IDataContext to consolidate context adaptation.

### DIFF
--- a/codetools/contexts/api.py
+++ b/codetools/contexts/api.py
@@ -4,8 +4,8 @@ from .adapted_data_context import AdaptedDataContext
 from .data_context import DataContext, ListenableMixin, PersistableMixin
 from .function_filter_context import FunctionFilterContext
 from .geo_context import GeoContext
-from .i_context import (IContext, IListenableContext, IRestrictedContext,
-    IPersistableContext, ICheckpointable, defer_events)
+from .i_context import (ICheckpointable, IContext, IDataContext,
+    IListenableContext, IPersistableContext, IRestrictedContext, defer_events)
 from .iterable_adapted_data_context import IterableAdaptedDataContext
 from .multi_context import MultiContext
 from .traitslike_context_wrapper import TraitslikeContextWrapper

--- a/codetools/contexts/data_context.py
+++ b/codetools/contexts/data_context.py
@@ -21,8 +21,7 @@ from traits.adaptation.api import AdaptationOffer, \
 from traits.api import (Bool, Dict, HasTraits, Str, Supports,
                         adapt, provides, on_trait_change)
 
-from .i_context import (IContext, ICheckpointable, IListenableContext,
-                       IPersistableContext, IRestrictedContext)
+from .i_context import IContext, ICheckpointable, IDataContext
 from .items_modified_event import ItemsModifiedEvent, ItemsModified
 
 # This is copied from numerical_modeling.numeric_context.constants
@@ -230,9 +229,7 @@ class PersistableMixin(HasTraits):
                 file_object.close()
 
 
-
-@provides(ICheckpointable, IListenableContext, IPersistableContext,
-            IRestrictedContext)
+@provides(IDataContext)
 class DataContext(ListenableMixin, PersistableMixin, DictMixin):
     """ A simple context which fires events.
     """
@@ -365,15 +362,11 @@ class DataContext(ListenableMixin, PersistableMixin, DictMixin):
 # Define adaptation offers from IContext to other context protocols using
 # DataContext.
 
-i_context_adaptation_offers = []
-for interface in [ICheckpointable, IListenableContext, IPersistableContext,
-                  IRestrictedContext]:
-    offer = AdaptationOffer(
-        factory=lambda x: DataContext(subcontext=x),
-        from_protocol=IContext,
-        to_protocol=interface
-    )
-    i_context_adaptation_offers.append(offer)
+data_context_offer = AdaptationOffer(
+    factory=lambda x: DataContext(subcontext=x),
+    from_protocol=IContext,
+    to_protocol=IDataContext
+)
 
 
 def register_i_context_adapter_offers(adaptation_manager):
@@ -383,8 +376,7 @@ def register_i_context_adapter_offers(adaptation_manager):
     2) `dict` can be adapted to `ICheckpointable`
     """
 
-    for offer in i_context_adaptation_offers:
-        adaptation_manager.register_offer(offer)
+    adaptation_manager.register_offer(data_context_offer)
 
 
 # For backward compatibility, we register the adapters from `dict` globally

--- a/codetools/contexts/i_context.py
+++ b/codetools/contexts/i_context.py
@@ -223,6 +223,11 @@ class ICheckpointable(Interface):
         # here.
 
 
+class IDataContext(ICheckpointable, IListenableContext, IPersistableContext,
+                   IRestrictedContext):
+    """ Interface for full-featured contexts. """
+
+
 #### Adaptation ###############################################################
 
 class CheckPointableDictAdapter(object):

--- a/codetools/contexts/multi_context.py
+++ b/codetools/contexts/multi_context.py
@@ -18,13 +18,11 @@ from traits.api import (Bool, List, Str, Undefined, Supports,
     adapt, provides, on_trait_change)
 
 from .data_context import DataContext, ListenableMixin, PersistableMixin
-from .i_context import (ICheckpointable, IListenableContext,
-    IPersistableContext, IRestrictedContext)
+from .i_context import ICheckpointable, IDataContext, IRestrictedContext
 from .utils import safe_repr
 
 
-@provides(ICheckpointable, IListenableContext, IPersistableContext,
-            IRestrictedContext)
+@provides(IDataContext)
 class MultiContext(ListenableMixin, PersistableMixin, DictMixin):
     """ Wrap several subcontexts.
     """


### PR DESCRIPTION
I defined a new IDataContext as an interface for contexts that provide
the functionality of IListenable, IPersistable, IRestricted, and
ICheckpointable. DataContext and MultiContext are example concrete
implementations.

As a side effect of the change, we have one single adapter from
IContext to IDataContext (and, thus, implicitly to all of its component
interfaces). This drastically reduces the number of possible paths
in the adaptation network.
