### PR TITLE
Python 3 Port

### DIFF
--- a/codetools/__init__.py
+++ b/codetools/__init__.py
@@ -7,5 +7,6 @@ except ImportError:
     __version__ = 'not-built'
 
 __requires__ = [
+    'six',
     'traits',
 ]

--- a/codetools/blocks/analysis.py
+++ b/codetools/blocks/analysis.py
@@ -22,7 +22,7 @@ from ..util.functional import partial
 from ..util import graph
 from ..util.graph import closure
 from ..util.sequence import \
-    all, disjoint, intersect, is_sequence, union
+    disjoint, intersect, is_sequence, union
 from ..util import tree
 
 # Extend compiler.ast.Node with a structure-preserving children query

--- a/codetools/blocks/block.py
+++ b/codetools/blocks/block.py
@@ -15,6 +15,8 @@ from traceback import format_exc
 import types
 from uuid import UUID, uuid4
 
+from six import exec_
+
 from traits.api import (Bool, Dict, Either, HasTraits,
                                   Instance, List, Property, Str,
                                   cached_property, Event)
@@ -295,7 +297,7 @@ class Block(HasTraits):
                not continue_on_errors:
             if self.filename:
                 local_context['__file__'] = self.filename
-            exec self._code in global_context, local_context
+            exec_(self._code, global_context, local_context)
         else:
             if continue_on_errors:
                 exceptions = []

--- a/codetools/blocks/namespace_tools.py
+++ b/codetools/blocks/namespace_tools.py
@@ -11,6 +11,8 @@
 """
 from __future__ import absolute_import
 
+from six import exec_
+
 from .decorators import func2str
 
 ##############################################################################
@@ -76,7 +78,7 @@ def namespace(function):
         ns.update(positional)
         globs = function.func_globals
 
-        exec code_object in globs, ns
+        exec_(code_object, globs, ns)
 
         # Save the original function name in the namespace as
         # the attribute '_func_name'.

--- a/codetools/blocks/parser_.py
+++ b/codetools/blocks/parser_.py
@@ -11,6 +11,9 @@ from compiler.ast import Module
 from compiler.transformer import Transformer
 import token
 
+from six import exec_
+
+
 class BlockTransformer(Transformer, object):
     'Specialize how code parses into ASTs for Blocks.'
 
@@ -21,9 +24,10 @@ class BlockTransformer(Transformer, object):
     # What we rewrite 'from %s import *' into
     _rewrite_wildcard_into = '''
 import %s as __module
+import six as __six
 for name in dir(__module):
-    exec '%%s = __module.%%s' %% (name, name)
-del __module
+    __six.exec_('%%s = __module.%%s' %% (name, name))
+del __module, __six
 '''
 
     ###########################################################################

--- a/codetools/blocks/tests/test_namespace_tools.py
+++ b/codetools/blocks/tests/test_namespace_tools.py
@@ -1,5 +1,8 @@
 import os
+
 from numpy.testing import assert_equal, assert_
+from six import exec_
+
 from codetools.blocks.namespace_tools import *
 
 def test_Namespace_class():
@@ -89,7 +92,7 @@ def test_namespace_in_execfile():
 def test_namespace_in_exec():
     # Verify that namespace decorator does *NOT* work in exec'd code.
     dic = {'a':2, 'namespace':namespace}
-    exec code_to_exec in dic
+    exec_(code_to_exec, dic, dic)
     assert_equal(set(dic.keys()), set(['a', '__builtins__', 'namespace',
                                        'f', 'ns']))
     ns = dic['ns']

--- a/codetools/blocks2/analysis.py
+++ b/codetools/blocks2/analysis.py
@@ -12,7 +12,7 @@ from ..util.functional import partial
 from ..util import graph
 from ..util.graph import closure
 from ..util.sequence import \
-    all, disjoint, intersect, is_sequence, union
+    disjoint, intersect, is_sequence, union
 from ..util import tree
 
 # Extend compiler.ast.Node with a structure-preserving children query

--- a/codetools/blocks2/block.py
+++ b/codetools/blocks2/block.py
@@ -13,6 +13,8 @@ from traceback import format_exc
 import types
 from uuid import UUID, uuid4
 
+from six import exec_
+
 from traits.api import (Bool, Dict, Either, HasTraits,
                                   Instance, List, Property, Str,
                                   cached_property, Event)
@@ -21,9 +23,9 @@ from ..util.dict import map_keys, map_values
 from ..util import graph
 from ..util.sequence import is_sequence
 
-from analysis import NameFinder
+from .analysis import NameFinder
 
-from block_transformer import BlockTransformer
+from .block_transformer import BlockTransformer
 from codetools.blocks.compiler_unparse import unparse
 
 ###############################################################################
@@ -297,7 +299,7 @@ class Block(HasTraits):
                not continue_on_errors:
             if self.filename:
                 local_context['__file__'] = self.filename
-            exec self._code in global_context, local_context
+            exec_(self._code, global_context, local_context)
         else:
             if continue_on_errors:
                 exceptions = []

--- a/codetools/contexts/adapter/adapter_manager_mixin.py
+++ b/codetools/contexts/adapter/adapter_manager_mixin.py
@@ -8,18 +8,16 @@
 from __future__ import absolute_import
 
 # Enthought imports
-from traits.api import HasTraits, List, implements
+from traits.api import HasTraits, List, provides
 
 # Local imports
 from .i_adapter_manager import IAdapterManager
 
 
-class AdapterManagerMixin(HasTraits):
+class AdapterManagerMixin(IAdapterManager):
     """ Handles management of an adapter stack for objects that implement
         IContext.
     """
-
-    implements(IAdapterManager)
 
     ### Private AdapterManagerMixin traits #####################################
 

--- a/codetools/contexts/adapter/i_adapter.py
+++ b/codetools/contexts/adapter/i_adapter.py
@@ -1,6 +1,7 @@
-from traits.api import Interface
+from traits.api import ABCHasTraits
 
-class IAdapter(Interface):
+
+class IAdapter(ABCHasTraits):
     """ Handles management of an adapter stack for objects that implement
         IContext.
     """

--- a/codetools/contexts/adapter/i_adapter_manager.py
+++ b/codetools/contexts/adapter/i_adapter_manager.py
@@ -8,9 +8,10 @@
 
 from __future__ import absolute_import
 
-from traits.api import Interface
+from traits.api import ABCHasTraits
 
-class IAdapterManager(Interface):
+
+class IAdapterManager(ABCHasTraits):
     """ Handles management of an adapter stack for objects that implement
     IContext.
     """

--- a/codetools/contexts/adapter/masking_adapter.py
+++ b/codetools/contexts/adapter/masking_adapter.py
@@ -16,6 +16,7 @@ from numpy import NaN, empty, float64, iscomplex, isreal, ndarray
 
 # Enthought library imports
 from traits.api import Any, HasTraits
+from scimath.units.api import UnitArray
 
 # Local imports
 from .i_adapter import IAdapter
@@ -91,6 +92,9 @@ class MaskingAdapter(HasTraits):
             default_value, dtype = get_default_value_and_dtype(name, value)
             new = self._empty_of_local_shape(context, dtype=dtype)
             new.fill(default_value)
+            if isinstance(value, UnitArray):
+                new = new.view(UnitArray)
+                new.units = value.units
             ###new[self.mask] = value
             ###return name, new
 

--- a/codetools/contexts/adapter/name_adapter.py
+++ b/codetools/contexts/adapter/name_adapter.py
@@ -14,6 +14,7 @@ from traits.api import HasTraits, Dict, Str, provides
 # Local imports
 from .i_adapter import IAdapter
 
+
 @provides(IAdapter)
 class NameAdapter(HasTraits):
     """ Maps more descriptive names provided by the user to names in the context
@@ -46,4 +47,4 @@ class NameAdapter(HasTraits):
         """ Returns a list containing any keys (names) defined by this
             adapter.
         """
-        return self.map.keys()
+        return list(self.map.keys())

--- a/codetools/contexts/adapter/unit_manipulation_adapter.py
+++ b/codetools/contexts/adapter/unit_manipulation_adapter.py
@@ -133,7 +133,7 @@ class UnitManipulationAdapter(HasTraits):
             # Conversion requested (new_units exist), but a converter
             # wasn't found.
             msg = "Unable to find converter for type %s" % type(value)
-            raise ConversionError, msg
+            raise ConversionError(msg)
 
         return value
 

--- a/codetools/contexts/context_function.py
+++ b/codetools/contexts/context_function.py
@@ -1,7 +1,9 @@
 """ Allows a function to execute as if locals are a context
 """
-import dis, struct, new
+import dis
 from functools import wraps
+import struct
+import types
 
 ##############################################################################
 # Implementation Notes
@@ -80,7 +82,7 @@ def args_to_locals(co):
     co_code = compile_bytecode(patch_load_and_store(parse_bytecode(co.co_code),
                                    co.co_argcount, nglobals,
                                    nfreevars+ncellvars))
-    return new.code(0, co.co_nlocals+len(co.co_varnames)+nfreevars+ncellvars,
+    return types.CodeType(0, co.co_nlocals+len(co.co_varnames)+nfreevars+ncellvars,
         co.co_stacksize, co.co_flags & ~15,
         co_code, co.co_consts, co.co_names + co.co_cellvars + co.co_freevars
         + co.co_varnames, (),
@@ -153,10 +155,10 @@ def context_function(f, context_factory):
     """
 
     # values that we may as well pre-calculate
-    code = args_to_locals(f.func_code)
-    if f.func_closure:
-        free_var_dict = dict(zip(f.func_code.co_freevars[-len(f.func_closure):],
-                             (cell.cell_contents for cell in f.func_closure)))
+    code = args_to_locals(f.__code__)
+    if f.__closure__:
+        free_var_dict = dict(zip(f.__code__.co_freevars[-len(f.__closure__):],
+                             (cell.cell_contents for cell in f.__closure__)))
     else:
         free_var_dict = {}
 
@@ -165,25 +167,25 @@ def context_function(f, context_factory):
         loc = context_factory()
         for key, value in free_var_dict.items():
             loc[key] = value
-        arg_len = f.func_code.co_argcount
-        named_args = f.func_code.co_varnames[:arg_len]
-        if f.func_defaults:
-            defaults = dict(zip(named_args[-len(f.func_defaults):], f.func_defaults))
+        arg_len = f.__code__.co_argcount
+        named_args = f.__code__.co_varnames[:arg_len]
+        if f.__defaults__:
+            defaults = dict(zip(named_args[-len(f.__defaults__):], f.__defaults__))
         else:
             defaults = {}
         if arg_len < len(args):
-            if f.func_code.co_flags & 4:
+            if f.__code__.co_flags & 4:
                 loc.update(dict(zip(named_args, args[:arg_len])))
-                loc[f.func_code.co_varnames[arg_len]] = args[arg_len:]
-                if f.func_code.co_flags & 8:
-                    loc[f.func_code.co_varnames[arg_len+1]] = kwargs
+                loc[f.__code__.co_varnames[arg_len]] = args[arg_len:]
+                if f.__code__.co_flags & 8:
+                    loc[f.__code__.co_varnames[arg_len+1]] = kwargs
             else:
                 # too many args
                 raise TypeError
         else:
             loc.update(dict(zip(named_args[:len(args)], args)))
-            if f.func_code.co_flags & 4:
-                loc[f.func_code.co_varnames[arg_len]] = ()
+            if f.__code__.co_flags & 4:
+                loc[f.__code__.co_varnames[arg_len]] = ()
             for arg in named_args[len(args):]:
                 if arg in kwargs:
                     loc[arg] = kwargs[arg]
@@ -196,16 +198,16 @@ def context_function(f, context_factory):
                 if arg in kwargs:
                     del kwargs[arg]
             if kwargs:
-                if f.func_code.co_flags & 8:
-                    if f.func_code.co_flags & 4:
+                if f.__code__.co_flags & 8:
+                    if f.__code__.co_flags & 4:
                         kwarg_no = arg_len + 1
                     else:
                         kwarg_no = arg_len
-                    loc[f.func_code.co_varnames[kwarg_no]] = kwargs
+                    loc[f.__code__.co_varnames[kwarg_no]] = kwargs
                 else:
                     # incorrect kwargs
                     raise TypeError
-        return eval(code, f.func_globals, loc)
+        return eval(code, f.__globals__, loc)
 
     return new_f
 

--- a/codetools/contexts/context_function.py
+++ b/codetools/contexts/context_function.py
@@ -66,7 +66,7 @@ def patch_load_and_store(ops, argcount, nglobals, ncellandfreevars):
             op = 'STORE_NAME'
             arg += nglobals
         elif op == "LOAD_CLOSURE":
-            raise ContextFunctionError, "can't create context_function for function containing closure"
+            raise ContextFunctionError("can't create context_function for function containing closure")
         elif op in dis.hasname:
             arg += argcount
         yield op, arg

--- a/codetools/contexts/data_context.py
+++ b/codetools/contexts/data_context.py
@@ -68,7 +68,7 @@ class ListenableMixin(ABCHasTraits):
 
     def _defer_events_changed_refire(self, new, event_attribute='items_modified'):
         if not new:
-            for key, event in self._deferred_events.items():
+            for key, event in list(self._deferred_events.items()):
 
                 added = event.added
                 removed = event.removed
@@ -262,7 +262,7 @@ class DataContext(ListenableMixin, PersistableMixin, DictMixin):
         # Figure out if the item was added or modified
         added = []
         modified = []
-        if key in self.subcontext.keys():
+        if key in self.subcontext:
             modified = [key]
         else:
             added = [key]
@@ -286,7 +286,7 @@ class DataContext(ListenableMixin, PersistableMixin, DictMixin):
         -------
         keys : list of str
         """
-        return self.subcontext.keys()
+        return list(self.subcontext.keys())
 
     # Expose DictMixin's get method over HasTraits'.
     get = DictMixin.get
@@ -301,20 +301,19 @@ class DataContext(ListenableMixin, PersistableMixin, DictMixin):
 
     #### DictMixin interface ##################################################
 
-    def __cmp__(self, other):
-        # FIXME: Implement __eq__ and __ne__ instead.
-        #
-        # Dont allow objects of different inherited classes to be equal.
-        # This WILL ALLOW different instances with different names but the
-        # same keys and values to be equal
-        #
-        # Subclasses may wish to override this to compare different attributes
-        #
+    def __eq__(self, other):
+        """ Don't allow objects of different classes to be equal.
 
-        cls_cmp = cmp(self.__class__, other.__class__)
-        if cls_cmp != 0:
-            return cls_cmp
-        return DictMixin.__cmp__(self, other)
+        This will allow different instances with different names but the same
+        keys and values to be equal. Subclasses may wish to override this to
+        compare different attributes.
+        """
+        if type(other) is not type(self):
+            return False
+        return DictMixin.__eq__(self, other)
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
     #### IRestrictedContext interface ##########################################
 

--- a/codetools/contexts/data_context.py
+++ b/codetools/contexts/data_context.py
@@ -245,7 +245,7 @@ class DataContext(ListenableMixin, PersistableMixin, DictMixin):
     #### IContext interface ####################################################
 
     def __iter__(self):
-        return iter(self.subcontext)
+        return iter(self.keys())
 
     def __len__(self):
         return len(self.subcontext)

--- a/codetools/contexts/function_filter_context.py
+++ b/codetools/contexts/function_filter_context.py
@@ -9,7 +9,7 @@ import types
 import numpy
 
 # Local imports
-from data_context import DataContext
+from .data_context import DataContext
 
 
 class FunctionFilterContext(DataContext):

--- a/codetools/contexts/geo_context.py
+++ b/codetools/contexts/geo_context.py
@@ -56,8 +56,8 @@ if __name__ == '__main__':
     g['depth'] = UnitArray(arange(0., 5000., 100.), units = feet)
     g['foo'] = arange(30, 530.0, 10.)
 
-    print g.context_names
-    print g.get_index()
+    print(g.context_names)
+    print(g.get_index())
 
 
 ### EOF ------------------------------------------------------------------------

--- a/codetools/contexts/hdf5_context.py
+++ b/codetools/contexts/hdf5_context.py
@@ -72,7 +72,7 @@ class Hdf5Context(HasTraits):
             node_str = '.'.join(['self.file_object', dir])
             try:
                 node = eval(node_str)
-                if name in node._v_children.keys():
+                if name in list(node._v_children.keys()):
                     location = dir
                     break
             except tables.NoSuchNodeError:
@@ -105,7 +105,7 @@ class Hdf5Context(HasTraits):
             node_str = '.'.join(['self.file_object', dir])
             try:
                 node = eval(node_str)
-                all_names.update(node._v_leaves.keys())
+                all_names.update(list(node._v_leaves.keys()))
             except tables.NoSuchNodeError:
                 continue
 
@@ -118,8 +118,14 @@ class Hdf5Context(HasTraits):
         # Fixme: Extract and share (and improve) tree-walking code in keys()
         return ((k, self.__getitem__(k)) for k in self.keys())
 
+    def __len__(self):
+        return len(self.keys())
+
+    def __iter__(self):
+        return iter(self.keys())
+
     def __contains__(self, name):
-        return name in self.keys()
+        return name in list(self.keys())
 
     def __getitem__(self, name):
         """
@@ -133,7 +139,7 @@ class Hdf5Context(HasTraits):
             # Convert a dir such as 'root.foo.bar' to '/foo/bar'.
             slash_dir = '/' + '/'.join(dir.split('.')[1:])
             try:
-                node = self.file_object.getNode(slash_dir, name)
+                node = self.file_object.get_node(slash_dir, name)
             except tables.NoSuchNodeError:
                 continue
 
@@ -166,7 +172,6 @@ class Hdf5Context(HasTraits):
         """
         raise NotImplementedError
 
-
     def __delitem__(self, name):
         """ Delete an item from the context.
 
@@ -176,4 +181,3 @@ class Hdf5Context(HasTraits):
             this one.
         """
         raise NotImplementedError
-

--- a/codetools/contexts/iterable_adapted_data_context.py
+++ b/codetools/contexts/iterable_adapted_data_context.py
@@ -8,10 +8,11 @@
 from __future__ import absolute_import
 
 # python standard library imports
-from UserDict import DictMixin
+from collections import MutableMapping as DictMixin
 
 # Enthought library imports
 from .adapted_data_context import AdaptedDataContext
+
 
 class IterableAdaptedDataContext(AdaptedDataContext):
     """ An AdaptedDataContext whose iteration includes any key mapped

--- a/codetools/contexts/masks/context_mask.py
+++ b/codetools/contexts/masks/context_mask.py
@@ -42,7 +42,7 @@ class ContextMask(object):
 
         if len(self.indices):
             for name in self.context.keys():
-                if self.value_dict.has_key(name):
+                if name in self.value_dict:
                     self.context[name][self.indices] = self.value_dict[name]
 
         return self.context
@@ -59,7 +59,7 @@ class ContextMask(object):
         # Revert all the changes done in __enter__ method.
         if len(self.indices):
             for name in self.context.keys():
-                if self.value_dict.has_key(name):
+                if name in self.value_dict:
                     self.context[name][self.indices] = \
                                     self.init_value_dict[name]
 

--- a/codetools/contexts/masks/index_context_mask.py
+++ b/codetools/contexts/masks/index_context_mask.py
@@ -36,7 +36,7 @@ class IndexContextMask(ContextMask):
         index = None
         if hasattr(context, 'get_index'):
             index = context.get_index()
-        elif context.has_key('index'):
+        elif 'index' in context:
             index = context['index']
 
         if index is not None and isinstance(index, numpy.ndarray):

--- a/codetools/contexts/multi_context.py
+++ b/codetools/contexts/multi_context.py
@@ -43,6 +43,12 @@ class MultiContext(ListenableMixin, PersistableMixin, DictMixin):
 
     #### IContext interface ####################################################
 
+    def __iter__(self):
+        return iter(self.keys())
+
+    def __len__(self):
+        return len(list(self.keys()))
+
     def __contains__(self, key):
         for c in self.subcontexts:
             if key in c:
@@ -139,7 +145,7 @@ class MultiContext(ListenableMixin, PersistableMixin, DictMixin):
             raise ValueError('Disallowed mapping: %s = %s' % (key, safe_repr(value)))
 
     def keys(self):
-        return list(set(chain(*[c.keys() for c in self.subcontexts])))
+        return list(set(chain(*[list(c.keys()) for c in self.subcontexts])))
 
 
     # Expose DictMixin's get method over HasTraits'.
@@ -189,12 +195,12 @@ class MultiContext(ListenableMixin, PersistableMixin, DictMixin):
         # Add to the list of items added
         if len(event.added):
             for context in event.added:
-                added.extend(context.keys())
+                added.extend(list(context.keys()))
 
         # Add to the list of items removed
         if len(event.removed):
             for context in event.removed:
-                removed.extend(context.keys())
+                removed.extend(list(context.keys()))
 
         self._fire_event(added=added, removed=removed)
 

--- a/codetools/contexts/multi_context.py
+++ b/codetools/contexts/multi_context.py
@@ -12,7 +12,7 @@
 from __future__ import absolute_import
 
 from itertools import chain
-from UserDict import DictMixin
+from collections import MutableMapping as DictMixin
 
 from traits.api import (Bool, List, Str, Undefined, Supports,
     adapt, provides, on_trait_change)

--- a/codetools/contexts/tests/abstract_context_test_case.py
+++ b/codetools/contexts/tests/abstract_context_test_case.py
@@ -1,8 +1,7 @@
 # Standard Library Imports
-from itertools import imap
+from collections import MutableMapping as DictMixin
 import timeit
 import unittest
-from UserDict import DictMixin
 
 # Numeric library imports
 from numpy import all
@@ -39,8 +38,12 @@ def adapt_keys(context):
             self._m[to_str(x)] = value
         def __delitem__(self, x):
             del self._m[to_str(x)]
+        def __iter__(self):
+            return iter(list(self.keys()))
+        def __len__(self):
+            return len(self._m)
         def keys(self):
-            return map(from_str, self._m.keys())
+            return map(from_str, list(self._m.keys()))
 
     return KeyAdapter(context)
 

--- a/codetools/contexts/tests/abstract_context_test_case.py
+++ b/codetools/contexts/tests/abstract_context_test_case.py
@@ -179,7 +179,7 @@ class AbstractContextTestCase(BasicTestMappingProtocol):
         input, output = self.matched_input_output_pair()
 
         context[key_name] = input
-        self.assertTrue(context.has_key(key_name))
+        self.assertTrue(key_name in context)
 
         return
 
@@ -189,7 +189,7 @@ class AbstractContextTestCase(BasicTestMappingProtocol):
         context = self.context_factory()
         key_name = self.key_name()
 
-        self.assertFalse(context.has_key(key_name))
+        self.assertFalse(key_name in context)
 
         return
 
@@ -261,7 +261,7 @@ class AbstractContextTestCase(BasicTestMappingProtocol):
         """
         context[key_name] = input
         del context[key_name]
-        self.assertFalse(context.has_key(key_name))
+        self.assertFalse(key_name in context)
 
         return
 

--- a/codetools/contexts/tests/abstract_context_test_case.py
+++ b/codetools/contexts/tests/abstract_context_test_case.py
@@ -77,8 +77,7 @@ class AbstractContextTestCase(BasicTestMappingProtocol):
            We've overloaded this here to handle arrays.
         """
         if not all(first == second):
-            raise self.failureException, \
-                  (msg or '%r != %r' % (first, second))
+            raise self.failureException(msg or '%r != %r' % (first, second))
 
     ############################################################################
     # BasicTestMappingProtocol interface

--- a/codetools/contexts/tests/context_function_test_case.py
+++ b/codetools/contexts/tests/context_function_test_case.py
@@ -3,9 +3,11 @@ import math
 import dis, inspect, pprint
 
 import numpy
+import six
 
-from codetools.contexts.context_function import context_function, \
-        ContextFunctionError, local_context
+if six.PY2:
+    from codetools.contexts.context_function import (
+        ContextFunctionError, context_function, local_context)
 
 c = 5.0
 
@@ -80,6 +82,10 @@ def internal_from(a):
 
 
 class ContextFunctionTestCase(unittest.TestCase):
+
+    def setUp(self):
+        if six.PY3:
+            raise unittest.SkipTest("context_function is not ported to Python 3")
 
     def test_func_attributes(self):
         c = 5.0
@@ -206,6 +212,10 @@ class ContextDecoratorTestCase(unittest.TestCase):
     We assume that if the basic functionality works, and context_function
     passes all tests, then local_context should be fine.
     """
+
+    def setUp(self):
+        if six.PY3:
+            raise unittest.SkipTest("context_function is not ported to Python 3")
 
     def test_basic_functionality(self):
         c = 5.0

--- a/codetools/contexts/tests/data_context_test_case.py
+++ b/codetools/contexts/tests/data_context_test_case.py
@@ -1,6 +1,6 @@
 
 # Standard Library Imports
-from cStringIO import StringIO
+from io import BytesIO
 import sys
 
 import nose
@@ -32,7 +32,7 @@ def test_persistence():
     d['a'] = 1
     d['b'] = 2
 
-    f = StringIO()
+    f = BytesIO()
     d.save(f)
     f.seek(0, 0)
     d2 = DataContext.load(f)

--- a/codetools/contexts/tests/events_test_case.py
+++ b/codetools/contexts/tests/events_test_case.py
@@ -1,4 +1,7 @@
 import unittest
+from unittest import SkipTest
+
+import six
 
 from codetools.contexts.data_context import DataContext
 from codetools.contexts.multi_context import MultiContext
@@ -101,6 +104,8 @@ class Events2TestCase(unittest.TestCase):
         self.assertEqual(self.last_event.removed, ['a'])
 
     def test_block_events(self):
+        if six.PY3:
+            raise SkipTest("skipping Block-using tests on Python 3")
         import numpy
         from codetools.blocks.api import Block
 

--- a/codetools/contexts/tests/function_filter_context_test_case.py
+++ b/codetools/contexts/tests/function_filter_context_test_case.py
@@ -3,7 +3,9 @@ import unittest
 
 # Geo library imports
 from codetools.contexts.function_filter_context import FunctionFilterContext
-from blockcanvas.debug.my_operator import add, mul, div, sub
+
+def add(x, y):
+    return x + y
 
 class FunctionFilterContextTestCase(unittest.TestCase):
     """ Test whether the context filters values by their type appropriately.
@@ -44,6 +46,3 @@ class FunctionFilterContextTestCase(unittest.TestCase):
 
         context['add'] = add
         self.assertEqual(context['add'], add)
-
-
-### EOF ------------------------------------------------------------------------

--- a/codetools/contexts/tests/hdf5_context_test_case.py
+++ b/codetools/contexts/tests/hdf5_context_test_case.py
@@ -1,7 +1,7 @@
 try:
     import tables
 except ImportError:
-    from nose.plugins.skip import Skip, SkipTest    
+    from nose.plugins.skip import Skip, SkipTest
     raise SkipTest("PyTables not installed")
 
 from codetools.contexts.hdf5_context import Hdf5Context
@@ -11,6 +11,9 @@ import numpy as np
 import os
 import unittest
 from nose.tools import assert_equal, assert_not_equal
+
+from six import exec_
+
 
 class Particle(tables.IsDescription):
     identity = tables.StringCol(itemsize=22, dflt=" ", pos=0)  # character String
@@ -124,6 +127,6 @@ class Hdf5ContextTest(unittest.TestCase):
                           path=['root', 'root.group1', 'root.group2'])
         results = DataContext()
         context = MultiContext(results, hdf_context)
-        exec 'array2_plus_one = [a2 + 1 for a2 in array2]' in {}, context
+        exec_('array2_plus_one = [a2 + 1 for a2 in array2]', {}, context)
         assert_equal(context['array2_plus_one'], [2, 3, 4, 5])
         table.close()

--- a/codetools/contexts/tests/hdf5_context_test_case.py
+++ b/codetools/contexts/tests/hdf5_context_test_case.py
@@ -23,21 +23,21 @@ class Particle(tables.IsDescription):
 def create_sample_hdf5_file(filename):
     """From the PyTables website."""
     # Open a file in "w"rite mode
-    fileh = tables.openFile(filename, mode = "w")
+    fileh = tables.open_file(filename, mode = "w")
     # Get the HDF5 root group
     root = fileh.root
 
     # Create the groups:
-    group1 = fileh.createGroup(root, "group1")
-    group2 = fileh.createGroup(root, "group2")
+    group1 = fileh.create_group(root, "group1")
+    group2 = fileh.create_group(root, "group2")
 
     # Now, create an array in root group
-    array1 = fileh.createArray(root, "array1", ["string", "array"], "String array")
+    array1 = fileh.create_array(root, "array1", ["string", "array"], "String array")
     # Create 2 new tables in group1
-    table1 = fileh.createTable(group1, "table1", Particle)
-    table2 = fileh.createTable("/group2", "table2", Particle)
+    table1 = fileh.create_table(group1, "table1", Particle)
+    table2 = fileh.create_table("/group2", "table2", Particle)
     # Create the last table in group2
-    array2 = fileh.createArray("/group1", "array2", [1,2,3,4])
+    array2 = fileh.create_array("/group1", "array2", [1,2,3,4])
 
     # Now, fill the tables:
     for table in (table1, table2):
@@ -70,63 +70,54 @@ class Hdf5ContextTest(unittest.TestCase):
 
     def test_empty_keys1(self):
         # test empty keys
-        table = tables.openFile('test.h5')
-        context = Hdf5Context(file_object=table)
-        assert_equal(len(context.keys()), 0)
-        print 'keys (should be empty):', context.keys()
-        print
-        table.close()
+        with tables.open_file('test.h5') as table:
+            context = Hdf5Context(file_object=table)
+            assert_equal(len(list(context.keys())), 0)
 
     def test_empty_keys2(self):
         # test empty keys
-        table = tables.openFile('test.h5')
-        context = Hdf5Context(file_object=table,
-                          path=['root', 'root.group1', 'root.group2'])
-        print 'keys (should have a lot of names):', context.keys()
-        assert_not_equal(len(context.keys()), 0)
-        table.close()
+        with tables.open_file('test.h5') as table:
+            context = Hdf5Context(file_object=table,
+                              path=['root', 'root.group1', 'root.group2'])
+            assert_not_equal(len(list(context.keys())), 0)
 
     def test_get_array1(self):
         # test getting array1 on root
-        table = tables.openFile('test.h5')
-        context = Hdf5Context(file_object=table,
-                          path=['root', 'root.group1', 'root.group2'])
-        array1 = context['array1']
-        assert_equal( len(array1), 2)
-        assert_equal( array1, ['string', 'array'])
-        assert_equal(context.location('array1'), 'root')
-        table.close()
+        with tables.open_file('test.h5') as table:
+            context = Hdf5Context(file_object=table,
+                              path=['root', 'root.group1', 'root.group2'])
+            array1 = context['array1']
+            assert_equal( len(array1), 2)
+            assert_equal( array1, ['string', 'array'])
+            assert_equal(context.location('array1'), 'root')
 
     def test_get_array2(self):
         # test getting array2 on root.group1
-        table = tables.openFile('test.h5')
-        context = Hdf5Context(file_object=table,
-                          path=['root', 'root.group1', 'root.group2'])
-        array2 = context['array2']
-        assert_equal( len(array2), 4)
-        assert_equal( array2, [1, 2, 3, 4])
-        assert_equal(context.location('array2'), 'root.group1')
-        table.close()
+        with tables.open_file('test.h5') as table:
+            context = Hdf5Context(file_object=table,
+                              path=['root', 'root.group1', 'root.group2'])
+            array2 = context['array2']
+            assert_equal( len(array2), 4)
+            assert_equal( array2, [1, 2, 3, 4])
+            assert_equal(context.location('array2'), 'root.group1')
 
     def test_get_table2(self):
         # test getting table2 on group2
-        table = tables.openFile('test.h5')
-        context = Hdf5Context(file_object=table,
-                          path=['root', 'root.group1', 'root.group2'])
-        table2 = context['table2']
-        assert_equal( len(table2), 10)
-        assert_equal(context.location('table2'), 'root.group2')
-        table.close()
+        with tables.open_file('test.h5') as table:
+            context = Hdf5Context(file_object=table,
+                              path=['root', 'root.group1', 'root.group2'])
+            table2 = context['table2']
+            assert_equal( len(table2), 10)
+            assert_equal(context.location('table2'), 'root.group2')
 
     def test_use_as_context(self):
         # Can we use the context as the namespace of a python calculation?
         from codetools.contexts.api import DataContext, MultiContext
 
-        table = tables.openFile('test.h5')
-        hdf_context = Hdf5Context(file_object=table,
-                          path=['root', 'root.group1', 'root.group2'])
-        results = DataContext()
-        context = MultiContext(results, hdf_context)
-        exec_('array2_plus_one = [a2 + 1 for a2 in array2]', {}, context)
-        assert_equal(context['array2_plus_one'], [2, 3, 4, 5])
-        table.close()
+        with tables.open_file('test.h5') as table:
+            hdf_context = Hdf5Context(file_object=table,
+                              path=['root', 'root.group1', 'root.group2'])
+            results = DataContext()
+            context = MultiContext(results, hdf_context)
+            exec_('array2_plus_one = [a2 + 1 for a2 in array2]', {}, context)
+            assert_equal(context['array2_plus_one'], [2, 3, 4, 5])

--- a/codetools/contexts/tests/mapping_test_case.py
+++ b/codetools/contexts/tests/mapping_test_case.py
@@ -3,12 +3,17 @@
 
 # tests common to dict and UserDict
 import unittest
-import UserDict
+
+import six
+from six.moves import UserDict
 
 
 class BasicTestMappingProtocol(unittest.TestCase):
     # This base class can be used to check that an object conforms to the
     # mapping protocol
+
+    if six.PY2:
+        assertCountEqual = unittest.TestCase.assertItemsEqual
 
     ############################################################################
     # unittest.TestCase interface
@@ -68,7 +73,7 @@ class BasicTestMappingProtocol(unittest.TestCase):
         #Indexing
         for key, value in self.reference.items():
             self.assertEqual(d[key], value)
-        knownkey = self.other.keys()[0]
+        knownkey = list(self.other.keys())[0]
         self.failUnlessRaises(KeyError, lambda:d[knownkey])
         #len
         self.assertEqual(len(p), 0)
@@ -81,26 +86,29 @@ class BasicTestMappingProtocol(unittest.TestCase):
             self.failIf(k in d)
             self.failIf(k in d)
         #cmp
-        self.assertEqual(cmp(p,p), 0)
-        self.assertEqual(cmp(d,d), 0)
-        self.assertEqual(cmp(p,d), -1)
-        self.assertEqual(cmp(d,p), 1)
+        self.assertEqual(p, p)
+        self.assertEqual(d, d)
+        self.assertNotEqual(p, d)
+        self.assertNotEqual(d, p)
         #__non__zero__
         if p: self.fail("Empty mapping must compare to False")
         if not d: self.fail("Full mapping must compare to True")
         # keys(), items(), iterkeys() ...
         def check_iterandlist(iter, lst, ref):
-            self.assert_(hasattr(iter, 'next'))
+            if six.PY3:
+                self.assert_(hasattr(iter, '__next__'))
+            else:
+                self.assert_(hasattr(iter, 'next'))
             self.assert_(hasattr(iter, '__iter__'))
             x = list(iter)
             self.assert_(set(x)==set(lst)==set(ref))
-        check_iterandlist(d.iterkeys(), d.keys(), self.reference.keys())
-        check_iterandlist(iter(d), d.keys(), self.reference.keys())
-        check_iterandlist(d.itervalues(), d.values(), self.reference.values())
-        check_iterandlist(d.iteritems(), d.items(), self.reference.items())
+        check_iterandlist(iter(d.keys()), list(d.keys()), list(self.reference.keys()))
+        check_iterandlist(iter(d), list(d.keys()), list(self.reference.keys()))
+        check_iterandlist(iter(d.values()), list(d.values()), list(self.reference.values()))
+        check_iterandlist(iter(d.items()), list(d.items()), list(self.reference.items()))
         #get
-        key, value = d.iteritems().next()
-        knownkey, knownvalue = self.other.iteritems().next()
+        key, value = next(iter(d.items()))
+        knownkey, knownvalue = next(iter(self.other.items()))
         self.assertEqual(d.get(key, knownvalue), value)
         self.assertEqual(d.get(knownkey, knownvalue), knownvalue)
         self.failIf(knownkey in d)
@@ -119,14 +127,14 @@ class BasicTestMappingProtocol(unittest.TestCase):
         #update
         p.update(self.reference)
         self.assertEqual(dict(p), self.reference)
-        items = p.items()
+        items = list(p.items())
         p = self._empty_mapping()
         p.update(items)
         self.assertEqual(dict(p), self.reference)
         d = self._full_mapping(self.reference)
         #setdefault
-        key, value = d.iteritems().next()
-        knownkey, knownvalue = self.other.iteritems().next()
+        key, value = next(iter(list(d.items())))
+        knownkey, knownvalue = next(iter(list(self.other.items())))
         self.assertEqual(d.setdefault(key, knownvalue), value)
         self.assertEqual(d[key], value)
         self.assertEqual(d.setdefault(knownkey, knownvalue), knownvalue)
@@ -158,21 +166,21 @@ class BasicTestMappingProtocol(unittest.TestCase):
 
     def test_keys(self):
         d = self._empty_mapping()
-        self.assertEqual(d.keys(), [])
+        self.assertEqual(list(d.keys()), [])
         d = self.reference
-        self.assert_(self.inmapping.keys()[0] in d.keys())
-        self.assert_(self.other.keys()[0] not in d.keys())
+        self.assert_(list(self.inmapping.keys())[0] in list(d.keys()))
+        self.assert_(list(self.other.keys())[0] not in list(d.keys()))
         self.assertRaises(TypeError, d.keys, None)
 
     def test_values(self):
         d = self._empty_mapping()
-        self.assertEqual(d.values(), [])
+        self.assertEqual(list(d.values()), [])
 
         self.assertRaises(TypeError, d.values, None)
 
     def test_items(self):
         d = self._empty_mapping()
-        self.assertEqual(d.items(), [])
+        self.assertEqual(list(d.items()), [])
 
         self.assertRaises(TypeError, d.items, None)
 
@@ -182,7 +190,7 @@ class BasicTestMappingProtocol(unittest.TestCase):
 
     def test_getitem(self):
         d = self.reference
-        self.assertEqual(d[self.inmapping.keys()[0]], self.inmapping.values()[0])
+        self.assertEqual(d[list(self.inmapping.keys())[0]], list(self.inmapping.values())[0])
 
         self.assertRaises(TypeError, d.__getitem__)
 
@@ -190,7 +198,7 @@ class BasicTestMappingProtocol(unittest.TestCase):
         # mapping argument
         d = self._empty_mapping()
         d.update(self.other)
-        self.assertEqual(d.items(), self.other.items())
+        self.assertEqual(list(d.items()), list(self.other.items()))
 
         # No argument
         d = self._empty_mapping()
@@ -199,13 +207,13 @@ class BasicTestMappingProtocol(unittest.TestCase):
 
         # item sequence
         d = self._empty_mapping()
-        d.update(self.other.items())
-        self.assertEqual(d.items(), self.other.items())
+        d.update(list(self.other.items()))
+        self.assertEqual(list(d.items()), list(self.other.items()))
 
         # Iterator
         d = self._empty_mapping()
-        d.update(self.other.iteritems())
-        self.assertEqual(d.items(), self.other.items())
+        d.update(iter(self.other.items()))
+        self.assertEqual(list(d.items()), list(self.other.items()))
 
         # FIXME: Doesn't work with UserDict
         # self.assertRaises((TypeError, AttributeError), d.update, None)
@@ -216,16 +224,14 @@ class BasicTestMappingProtocol(unittest.TestCase):
             def __init__(self):
                 self.d = outerself.reference
             def keys(self):
-                return self.d.keys()
+                return list(self.d.keys())
             def __getitem__(self, i):
                 return self.d[i]
         d.clear()
         d.update(SimpleUserDict())
-        i1 = d.items()
-        i2 = self.reference.items()
-        i1.sort()
-        i2.sort()
-        self.assertEqual(i1, i2)
+        i1 = list(d.items())
+        i2 = list(self.reference.items())
+        self.assertCountEqual(i1, i2)
 
         class Exc(Exception): pass
 
@@ -244,11 +250,12 @@ class BasicTestMappingProtocol(unittest.TestCase):
                         self.i = 1
                     def __iter__(self):
                         return self
-                    def next(self):
+                    def __next__(self):
                         if self.i:
                             self.i = 0
                             return 'a'
                         raise Exc
+                    next = __next__
                 return BogonIter()
             def __getitem__(self, key):
                 return key
@@ -261,12 +268,13 @@ class BasicTestMappingProtocol(unittest.TestCase):
                         self.i = ord('a')
                     def __iter__(self):
                         return self
-                    def next(self):
+                    def __next__(self):
                         if self.i <= ord('z'):
                             rtn = chr(self.i)
                             self.i += 1
                             return rtn
                         raise StopIteration
+                    next = __next__
                 return BogonIter()
             def __getitem__(self, key):
                 raise Exc
@@ -276,8 +284,9 @@ class BasicTestMappingProtocol(unittest.TestCase):
         class badseq(object):
             def __iter__(self):
                 return self
-            def next(self):
+            def __next__(self):
                 raise Exc()
+            next = __next__
 
         self.assertRaises(Exc, d.update, badseq())
 
@@ -287,13 +296,13 @@ class BasicTestMappingProtocol(unittest.TestCase):
 
     def test_get(self):
         d = self._empty_mapping()
-        self.assert_(d.get(self.other.keys()[0]) is None)
-        self.assertEqual(d.get(self.other.keys()[0], 3), 3)
+        self.assert_(d.get(list(self.other.keys())[0]) is None)
+        self.assertEqual(d.get(list(self.other.keys())[0], 3), 3)
         d = self.reference
-        self.assert_(d.get(self.other.keys()[0]) is None)
-        self.assertEqual(d.get(self.other.keys()[0], 3), 3)
-        self.assertEqual(d.get(self.inmapping.keys()[0]), self.inmapping.values()[0])
-        self.assertEqual(d.get(self.inmapping.keys()[0], 3), self.inmapping.values()[0])
+        self.assert_(d.get(list(self.other.keys())[0]) is None)
+        self.assertEqual(d.get(list(self.other.keys())[0], 3), 3)
+        self.assertEqual(d.get(list(self.inmapping.keys())[0]), list(self.inmapping.values())[0])
+        self.assertEqual(d.get(list(self.inmapping.keys())[0], 3), list(self.inmapping.values())[0])
         self.assertRaises(TypeError, d.get)
         self.assertRaises(TypeError, d.get, None, None, None)
 
@@ -308,9 +317,9 @@ class BasicTestMappingProtocol(unittest.TestCase):
 
     def test_pop(self):
         d = self._empty_mapping()
-        k, v = self.inmapping.items()[0]
+        k, v = list(self.inmapping.items())[0]
         d[k] = v
-        self.assertRaises(KeyError, d.pop, self.other.keys()[0])
+        self.assertRaises(KeyError, d.pop, list(self.other.keys())[0])
 
         self.assertEqual(d.pop(k), v)
         self.assertEqual(len(d), 0)
@@ -350,9 +359,9 @@ class TestMappingProtocol(BasicTestMappingProtocol):
     def test_keys(self):
         BasicTestMappingProtocol.test_keys(self)
         d = self._empty_mapping()
-        self.assertEqual(d.keys(), [])
+        self.assertEqual(list(d.keys()), [])
         d = self._full_mapping({'a': 1, 'b': 2})
-        k = d.keys()
+        k = list(d.keys())
         self.assert_('a' in k)
         self.assert_('b' in k)
         self.assert_('c' not in k)
@@ -360,19 +369,19 @@ class TestMappingProtocol(BasicTestMappingProtocol):
     def test_values(self):
         BasicTestMappingProtocol.test_values(self)
         d = self._full_mapping({1:2})
-        self.assertEqual(d.values(), [2])
+        self.assertEqual(list(d.values()), [2])
 
     def test_items(self):
         BasicTestMappingProtocol.test_items(self)
 
         d = self._full_mapping({1:2})
-        self.assertEqual(d.items(), [(1, 2)])
+        self.assertEqual(list(d.items()), [(1, 2)])
 
     def test_has_key(self):
         d = self._empty_mapping()
         self.assert_('a' not in d)
         d = self._full_mapping({'a': 1, 'b': 2})
-        k = d.keys()
+        k = list(d.keys())
         k.sort()
         self.assertEqual(k, ['a', 'b'])
 
@@ -447,14 +456,14 @@ class TestMappingProtocol(BasicTestMappingProtocol):
 
         # iterator
         d = self._full_mapping({1:3, 2:4})
-        d.update(self._full_mapping({1:2, 3:4, 5:6}).iteritems())
+        d.update(iter(self._full_mapping({1:2, 3:4, 5:6}).items()))
         self.assertEqual(d, {1:2, 2:4, 3:4, 5:6})
 
         class SimpleUserDict:
             def __init__(self):
                 self.d = {1:1, 2:2, 3:3}
             def keys(self):
-                return self.d.keys()
+                return list(self.d.keys())
             def __getitem__(self, i):
                 return self.d[i]
         d.clear()
@@ -481,7 +490,7 @@ class TestMappingProtocol(BasicTestMappingProtocol):
         # self.assert_(type(dictlike.fromkeys('a')) is dictlike)
         class mydict(self.type2test):
             def __new__(cls):
-                return UserDict.UserDict()
+                return UserDict()
         ud = mydict.fromkeys('ab')
         self.assertEqual(ud, {'a':None, 'b':None})
         # FIXME: the following won't work with UserDict, because it's an old style class
@@ -499,8 +508,9 @@ class TestMappingProtocol(BasicTestMappingProtocol):
         class BadSeq(object):
             def __iter__(self):
                 return self
-            def next(self):
+            def __next__(self):
                 raise Exc()
+            next = __next__
 
         self.assertRaises(Exc, self.type2test.fromkeys, BadSeq())
 
@@ -623,10 +633,10 @@ class TestHashMappingProtocol(TestMappingProtocol):
         TestMappingProtocol.test_fromkeys(self)
         class mydict(self.type2test):
             def __new__(cls):
-                return UserDict.UserDict()
+                return UserDict()
         ud = mydict.fromkeys('ab')
         self.assertEqual(ud, {'a':None, 'b':None})
-        self.assert_(isinstance(ud, UserDict.UserDict))
+        self.assert_(isinstance(ud, UserDict))
 
     def test_pop(self):
         TestMappingProtocol.test_pop(self)

--- a/codetools/contexts/tests/mapping_test_case.py
+++ b/codetools/contexts/tests/mapping_test_case.py
@@ -571,13 +571,6 @@ class TestMappingProtocol(BasicTestMappingProtocol):
         d = self._empty_mapping()
         k, v = 'abc', 'def'
 
-        # verify longs/ints get same value when key > 32 bits (for 64-bit archs)
-        # see SF bug #689659
-        x = 4503599627370496L
-        y = 4503599627370496
-        h = self._full_mapping({x: 'anything', y: 'something else'})
-        self.assertEqual(h[x], h[y])
-
         self.assertEqual(d.pop(k, v), v)
         d[k] = v
         self.assertEqual(d.pop(k, 1), v)
@@ -685,7 +678,6 @@ class TestHashMappingProtocol(TestMappingProtocol):
 
     def test_le(self):
         self.assert_(not (self._empty_mapping() < self._empty_mapping()))
-        self.assert_(not (self._full_mapping({1: 2}) < self._full_mapping({1L: 2L})))
 
         class Exc(Exception): pass
 

--- a/codetools/contexts/tests/mapping_test_case.py
+++ b/codetools/contexts/tests/mapping_test_case.py
@@ -75,10 +75,10 @@ class BasicTestMappingProtocol(unittest.TestCase):
         self.assertEqual(len(d), len(self.reference))
         #has_key
         for k in self.reference:
-            self.assert_(d.has_key(k))
+            self.assert_(k in d)
             self.assert_(k in d)
         for k in self.other:
-            self.failIf(d.has_key(k))
+            self.failIf(k in d)
             self.failIf(k in d)
         #cmp
         self.assertEqual(cmp(p,p), 0)
@@ -370,7 +370,7 @@ class TestMappingProtocol(BasicTestMappingProtocol):
 
     def test_has_key(self):
         d = self._empty_mapping()
-        self.assert_(not d.has_key('a'))
+        self.assert_('a' not in d)
         d = self._full_mapping({'a': 1, 'b': 2})
         k = d.keys()
         k.sort()

--- a/codetools/contexts/tests/multi_context_test_case.py
+++ b/codetools/contexts/tests/multi_context_test_case.py
@@ -1,5 +1,5 @@
 # Standard library imports
-from cStringIO import StringIO
+from io import BytesIO
 import os
 import sys
 import unittest
@@ -95,21 +95,21 @@ class MultiContextTestCase(AbstractContextTestCase):
         d2 = DataContext(name = 'test_context2')
 
         m = MultiContext(*[d1,d2], **{'name': 'test_mc'})
-        self.assertTrue(len(m.keys()) == 2)
+        self.assertTrue(len(list(m.keys())) == 2)
 
         # Add another context
         d3 = DataContext(name = 'test_context3',
                          subcontext = {'c':3, 'd':4})
         m.subcontexts.append(d3)
-        self.assertTrue(len(m.keys()) == 4)
+        self.assertTrue(len(list(m.keys())) == 4)
 
         # Modify an existing context
         m.subcontexts[1].subcontext = {'cc': 5}
-        self.assertTrue(len(m.keys()) == 5)
+        self.assertTrue(len(list(m.keys())) == 5)
 
         # Remove a context
         m.subcontexts.pop(0)
-        self.assertTrue(len(m.keys()) == 3)
+        self.assertTrue(len(list(m.keys())) == 3)
 
 
 def test_persistence():
@@ -121,7 +121,7 @@ def test_persistence():
                      subcontext = {'foo':100, 'bar':200, 'baz':300})
     m = MultiContext(d1, d2, name='test_mc')
 
-    f = StringIO()
+    f = BytesIO()
     m.save(f)
     f.seek(0, 0)
     new_m = MultiContext.load(f)

--- a/codetools/contexts/tests/with_mask_test_case.py
+++ b/codetools/contexts/tests/with_mask_test_case.py
@@ -6,11 +6,11 @@ import os, unittest
 
 # Major library imports
 from numpy import arange, zeros
+import six
 
 # ETS imports
 from codetools.contexts.with_mask import Mask
 from codetools.contexts.data_context import DataContext
-from codetools.blocks.api import Block
 
 
 class WithMaskTestCase(unittest.TestCase):
@@ -45,8 +45,7 @@ class WithMaskTestCase(unittest.TestCase):
         code = file_object.read()
         file_object.close()
 
-        b = Block(code)
-        b.execute(self.context)
+        six.exec_(code, {}, self.context)
 
         depth = arange(0., 10000., 1000.)
         desired_vp = zeros(depth.shape)
@@ -67,8 +66,7 @@ class WithMaskTestCase(unittest.TestCase):
         code = file_object.read()
         file_object.close()
 
-        b = Block(code)
-        b.execute(self.context)
+        six.exec_(code, {}, self.context)
 
         depth = arange(0., 10000., 1000.)
         desired_vp = zeros(depth.shape)
@@ -89,8 +87,7 @@ class WithMaskTestCase(unittest.TestCase):
         code = file_object.read()
         file_object.close()
 
-        b = Block(code)
-        b.execute(self.context)
+        six.exec_(code, {}, self.context)
 
         desired_vp = arange(0., 10., 1.)
         desired_vs = arange(0., 100., 10.)

--- a/codetools/contexts/traitslike_context_wrapper.py
+++ b/codetools/contexts/traitslike_context_wrapper.py
@@ -55,12 +55,12 @@ class TraitslikeContextWrapper(HasTraits):
         >>> tcw.add_traits('a', 'b', c=Int)
         """
         if self._context is not None:
-            keys = self._context.keys()
+            keys = list(self._context.keys())
         else:
             keys = []
 
         with self._synch_off():
-            for name, trait in [(x, Any()) for x in args] + kwds.items():
+            for name, trait in [(x, Any()) for x in args] + list(kwds.items()):
                 self.add_trait(name, Trait(trait, in_context=True))
                 # Set the value to that in the context.
                 if name in keys:

--- a/codetools/contexts/with_mask.py
+++ b/codetools/contexts/with_mask.py
@@ -152,7 +152,7 @@ class Mask(object):
         """ Enter method.
         """
         locals_val = sys._getframe().f_back.f_locals
-        if locals_val.has_key('context') and isinstance(locals_val['context'],
+        if 'context' in locals_val and isinstance(locals_val['context'],
                                                         dict):
             locals_val = locals_val['context']
 
@@ -170,7 +170,7 @@ class Mask(object):
         """ Exit method.
         """
         locals_val = sys._getframe().f_back.f_locals
-        if locals_val.has_key('context') and isinstance(locals_val['context'],
+        if 'context' in locals_val and isinstance(locals_val['context'],
                                                         dict):
             locals_val = locals_val['context']
 

--- a/codetools/contexts/with_mask.py
+++ b/codetools/contexts/with_mask.py
@@ -174,8 +174,8 @@ class Mask(object):
                                                         dict):
             locals_val = locals_val['context']
 
-        for k in locals_val.keys():
-            if k in self.context.keys() and isinstance(self.context[k],
+        for k in list(locals_val.keys()):
+            if k in list(self.context.keys()) and isinstance(self.context[k],
                                                        ndarray):
                 equal_values = self.context[k] == locals_val[k]
                 if isinstance(equal_values, ndarray):

--- a/codetools/contexts/with_mask.py
+++ b/codetools/contexts/with_mask.py
@@ -238,7 +238,7 @@ if __name__ == '__main__':
 
     b = Block(code)
     b.execute(context)
-    print 'vp', context['vp']
-    print 'vs', context['vs']
+    print('vp', context['vp'])
+    print('vs', context['vs'])
 
 ### EOF ------------------------------------------------------------------------

--- a/codetools/contexts/with_mask_adapter.py
+++ b/codetools/contexts/with_mask_adapter.py
@@ -10,6 +10,7 @@ from __future__ import absolute_import
 
 # Standard imports
 from numpy import ndarray, ones, NaN
+import six
 
 # Enthought library imports
 from traits.api import Any, HasTraits, provides
@@ -77,7 +78,7 @@ class WithMaskAdapter(HasTraits):
 
             # If the new value is a singleton that has to be applied to the
             # masked values alone.
-            elif type(value) in [float, int, str, unicode]:
+            elif isinstance(value, (float, int, bytes) + six.string_types):
                 context[name][self.mask] = value
 
             return name, context[name]

--- a/codetools/contexts/with_mask_adapter.py
+++ b/codetools/contexts/with_mask_adapter.py
@@ -66,7 +66,7 @@ class WithMaskAdapter(HasTraits):
         """
 
         # Condition for keeping the old array value
-        cond_keep_array = context.has_key(name) and \
+        cond_keep_array = name in context and \
                              isinstance(context[name], ndarray) and \
                              context[name].shape == self.mask.shape
 
@@ -82,7 +82,7 @@ class WithMaskAdapter(HasTraits):
 
             return name, context[name]
         else:
-            if context.has_key(name):
+            if name in context:
                 old_value = context[name]
                 if isinstance(old_value, ndarray):
                     old_value = old_value[0]

--- a/codetools/execution/demo/expression_context_demo.py
+++ b/codetools/execution/demo/expression_context_demo.py
@@ -1,4 +1,5 @@
-# Enthought library imports
+from six import exec_
+
 from traits.api import Code, HasTraits, Instance, Str, Button
 from traitsui.api import View, Group, Item
 from traitsui.wx.constants import WindowColor
@@ -47,7 +48,7 @@ class ExpressionContextDemo(HasTraits):
         return
 
     def _execute_fired(self):
-        exec self.code in {}, self.data_context
+        exec_(self.code, {}, self.data_context)
         return
 
 if __name__ == '__main__':

--- a/codetools/execution/executing_context.py
+++ b/codetools/execution/executing_context.py
@@ -17,6 +17,8 @@ from codetools.contexts.data_context import DataContext
 from codetools.contexts.i_context import IContext, IListenableContext
 from .interfaces import IExecutable, IExecutingContext
 
+from six import exec_
+
 
 @provides(IExecutable)
 class CodeExecutable(HasTraits):
@@ -37,7 +39,7 @@ class CodeExecutable(HasTraits):
         if globals is None:
             globals = {}
 
-        exec self.code in globals, icontext
+        exec_(self.code, globals, icontext)
         return set(inputs), set(outputs)
 
 

--- a/codetools/execution/formula_executing_context.py
+++ b/codetools/execution/formula_executing_context.py
@@ -7,10 +7,10 @@
 #
 from __future__ import absolute_import
 
-# Global imports
 from copy import copy
 
-# Enthought library imports
+import six
+
 from traits.api import Str, Instance, Dict, on_trait_change, Bool, Supports
 from codetools.blocks.api import Block
 from codetools.contexts.data_context import DataContext
@@ -58,7 +58,7 @@ class FormulaExecutingContext(DataContext):
     # Dict interface
     def __setitem__(self, key, value):
         # FIXME this heuristic of looking for an = is somewhat brittle, but will work for our application
-        if isinstance(value, basestring) and '=' in value:
+        if isinstance(value, six.string_types) and '=' in value:
             #This is a formula
             self._expressions[key] = value.split('=')[1]
             self._regenerate_expression_block()

--- a/codetools/util/cbook.py
+++ b/codetools/util/cbook.py
@@ -11,7 +11,9 @@ A collection of utility functions and classes FROM MATPLOTLIB.
 Many (but not all) from the Python Cookbook -- hence the name cbook.
 """
 from __future__ import generators
-import re, os, errno, sys, StringIO, traceback
+import re, os, errno, sys, traceback
+
+from six import StringIO
 
 
 major, minor1, minor2, s, tmp = sys.version_info
@@ -234,9 +236,9 @@ class Null(object):
 
 
 
-def mkdirs(newdir, mode=0777):
+def mkdirs(newdir, mode=0o777):
    try: os.makedirs(newdir, mode)
-   except OSError, err:
+   except OSError as err:
       # Reraise the error unless it's about an already existing directory
       if err.errno != errno.EEXIST or not os.path.isdir(newdir):
          raise

--- a/codetools/util/dict.py
+++ b/codetools/util/dict.py
@@ -1,6 +1,6 @@
 'Non-standard dictionary functions'
 
-from sequence import intersect
+from .sequence import intersect
 
 def map_keys(f, d):
     ''' Map a function over the keys in a dictionary.
@@ -78,7 +78,7 @@ def sub_dict(d, keys):
         ...     sub_dict({1: 2}, [1, 3])
         ...     assert False
         ... except KeyError:
-        ...     print 'Key error!'
+        ...     print('Key error!')
         Key error!
     '''
     return dict([ (k, d[k]) for k in keys ])

--- a/codetools/util/functional.py
+++ b/codetools/util/functional.py
@@ -9,6 +9,9 @@
 
 from functools import partial
 
+from six.moves import reduce
+
+
 def compose(*fs):
     ''' ``compose(f,g,...,h)(*args, **kw) == f(g(...(h(*args, **kw))))``
 
@@ -18,7 +21,7 @@ def compose(*fs):
         2
         >>> compose()(1)
         1
-        >>> map(compose(sum, range, len), ['foo', 'asdf', 'wibble'])
+        >>> list(map(compose(sum, range, len), ['foo', 'asdf', 'wibble']))
         [3, 6, 15]
     '''
 

--- a/codetools/util/graph.py
+++ b/codetools/util/graph.py
@@ -20,7 +20,6 @@ A graph is represented by a dictionary which represents the adjacency relation,
 where node ``a`` has an arc to node ``b`` if and only if ``b in d[a]``.
 """
 
-import __builtin__
 from itertools import chain
 
 # Expose the topological sort function from traits.util here too.
@@ -28,6 +27,8 @@ from traits.util.toposort import CyclicGraph, topological_sort
 
 from .cbook import flatten
 from .dict import map_items, map_values
+
+from six.moves import builtins
 
 
 def closure(graph, sorted=True):
@@ -91,7 +92,7 @@ def map(f, graph):
         >>> map(str, { 1:[2,3] })
         {'1': ['2', '3']}
     '''
-    return map_items(lambda k,v: (f(k), __builtin__.map(f,v)), graph)
+    return map_items(lambda k,v: (f(k), [f(x) for x in v]), graph)
 
 # FIXME Implement graphs with sets of values instead of lists of values
 def eq(g1, g2):
@@ -119,7 +120,7 @@ if __name__ == "__main__":
          2:[3,4],
          6:[3],
          4:[6]}
-    print topological_sort(g)
-    print closure(g)
+    print(topological_sort(g))
+    print(closure(g))
 
 #### EOF ######################################################################

--- a/codetools/util/sequence.py
+++ b/codetools/util/sequence.py
@@ -11,9 +11,6 @@ def is_sequence(x):
     except TypeError:
         return False
 
-all = lambda l: False not in map(bool, l)
-any = lambda l: True in map(bool, l)
-
 ###############################################################################
 # list
 ###############################################################################
@@ -31,7 +28,8 @@ def concat(lists):
         []
     '''
     l = []
-    map(l.extend, lists)
+    for sublist in lists:
+        l.extend(sublist)
     return l
 
 ###############################################################################
@@ -49,7 +47,8 @@ def union(sets):
         set([])
     '''
     s = set()
-    map(s.update, sets)
+    for subset in sets:
+        s.update(subset)
     return s
 
 def intersect(sets):
@@ -60,13 +59,14 @@ def intersect(sets):
         >>> intersect([set('ab'), set('bc'), set('ac')])
         set([])
         >>> try: intersect([])
-        ... except: print 'bad'
+        ... except: print('bad')
         ...
         bad
     '''
     sets = iter(sets)
-    s = copy(sets.next())
-    map(s.intersection_update, sets)
+    s = copy(next(sets))
+    for subset in sets:
+        s.intersection_update(subset)
     return s
 
 def disjoint(*sets):

--- a/codetools/util/tests/sequence_test_case.py
+++ b/codetools/util/tests/sequence_test_case.py
@@ -1,10 +1,46 @@
 import unittest
-from traits.testing.api import doctest_for_module
-import codetools.util.sequence as sequence
 
-class SequenceDocTestCase(doctest_for_module(sequence)):
-    pass
+from codetools.util.sequence import concat, disjoint, intersect, union
 
-if __name__ == '__main__':
-    import sys
-    unittest.main(argv=sys.argv)
+
+class SequenceTestCase(unittest.TestCase):
+
+    def test_concat(self):
+        self.assertEqual(
+            concat(range(i) for i in range(5)),
+            [0, 0, 1, 0, 1, 2, 0, 1, 2, 3],
+        )
+        self.assertEqual(
+            concat([[1,2], [3]]),
+            [1, 2, 3],
+        )
+        self.assertEqual(
+            concat([[1, 2, [3,4]], [5,6]]),
+            [1, 2, [3, 4], 5, 6],
+        )
+        self.assertEqual(
+            concat([]),
+            [],
+        )
+
+    def test_union(self):
+        self.assertTrue(
+            union([set('ab'), set('bc'), set('ac')]) == set('abc'))
+        self.assertEqual(union([]), set())
+
+    def test_intersect(self):
+        self.assertEqual(
+            intersect([set('ab'), set('bc'), set('bb')]),
+            set(['b']),
+        )
+        self.assertEqual(
+            intersect([set('ab'), set('bc'), set('ac')]),
+            set(),
+        )
+        with self.assertRaises(StopIteration):
+            intersect([])
+
+    def test_disjoint(self):
+        self.assertTrue(disjoint(set([1,2]), set([3])))
+        self.assertFalse(disjoint(set('abc'), set('xy'), set('z'), set('cde')))
+        self.assertTrue(disjoint())

--- a/codetools/util/tree.py
+++ b/codetools/util/tree.py
@@ -1,7 +1,14 @@
-'Functions on trees, that is, nested sequences.'
+"""Functions on trees, that is, nested sequences.
+"""
+
+import six
 
 from .functional import partial
-from .sequence import all, any, concat, is_sequence
+from .sequence import concat, is_sequence
+
+
+basestring = six.string_types[0]
+
 
 def is_fork(x, leaves=()):
     'Test whether a tree is a fork (instead of a leaf).'

--- a/setup.py
+++ b/setup.py
@@ -133,5 +133,4 @@ if __name__ == "__main__":
           packages=find_packages(),
           platforms=["Windows", "Linux", "Mac OS-X", "Unix", "Solaris"],
           zip_safe=False,
-          use2to3=True,
           )


### PR DESCRIPTION
`codetools.contexts` has been ported to Python 3.  A couple of features in here are not ported, like the `@context_function` decorator which manipulates bytecode. Tests that would exercise this feature have been skipped on Python 3.

`codetools.blocks`, `codetools.blocks2`, and `codetools.execution` (which depends on the former) are not yet ported as they will require a serious rewrite, rather than simple porting. They rely on the deprecated `compiler` module. They need to be ported to use the `ast` and generate Python 3-compatible code.

Eggs built from this branch will still contain the unported code; I didn't find a good way to exclude them, but I didn't try exhaustively. The test suites for the unported packages will be skipped on Python 3 when use `nosetests`.

I ported mostly according to the test suite, so some untested corners may still have cobwebs.