### PR TITLE
Skip persistence test for MultiContext - Py2

### DIFF
--- a/codetools/contexts/tests/multi_context_test_case.py
+++ b/codetools/contexts/tests/multi_context_test_case.py
@@ -5,6 +5,8 @@ import sys
 import unittest
 
 import nose
+from nose.plugins.skip import SkipTest
+import six
 
 # Enthought library imports
 from traits.api import Any
@@ -116,6 +118,8 @@ class MultiContextTestCase(AbstractContextTestCase):
 def test_persistence():
     """ Checking if the data persists correctly when saving and loading back
     """
+    if six.PY2:
+        raise SkipTest("Pickling MultiContext instances is broken on Python 2.")
     d1 = DataContext(name = 'test_context1',
                      subcontext = {'a':1, 'b':2})
     d2 = DataContext(name = 'test_context2',


### PR DESCRIPTION
The underlying traits pickling machinery seems to be broken with the latest release i.e. 5.0.0, leading to broken pickling of MultiContext instances on Python 2.

Given the move to Python 3, this has been deemed an acceptable bug on Python 2 so we skip the failing test.

Once this PR is merged, PR #25 and #27 can be updated to get CI working and the release process for the new release of codetools can be started.