### PR TITLE
Release version 4.3.0 of codetools

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,8 @@ Codetools Changelog
 Release 4.3.0
 -------------
 
+Released : 18 February 2019
+
 *NOTE* : Pickling `MultiContext` instances is broken on Python 2.
 See https://github.com/enthought/codetools/issues/30 for further details.
 

--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,10 @@ from setuptools import setup, find_packages
 
 
 MAJOR = 4
-MINOR = 3
+MINOR = 4
 MICRO = 0
 
-IS_RELEASED = True
+IS_RELEASED = False
 
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ MAJOR = 4
 MINOR = 3
 MICRO = 0
 
-IS_RELEASED = False
+IS_RELEASED = True
 
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 


### PR DESCRIPTION
fixes #23 

Note that the commit https://github.com/enthought/codetools/commit/c2a0c1b436c5f7381ed91139a777844d5677d1be will be tagged as the release commit after review/merge.