### PR TITLE
Replace deprecated rich_compare kwarg

### DIFF
--- a/codetools/contexts/traitslike_context_wrapper.py
+++ b/codetools/contexts/traitslike_context_wrapper.py
@@ -15,7 +15,7 @@ from __future__ import absolute_import
 from contextlib import contextmanager
 
 from traits.api import (Any, Bool, HasTraits, Supports, Trait,
-    Undefined, on_trait_change)
+    Undefined, on_trait_change, OBJECT_IDENTITY_COMPARE)
 
 from .i_context import IListenableContext
 
@@ -28,7 +28,9 @@ class TraitslikeContextWrapper(HasTraits):
     # that mirror the context.
 
     # The context we are wrapping.
-    _context = Supports(IListenableContext, rich_compare=False)
+    _context = Supports(
+        IListenableContext, comparison_mode=OBJECT_IDENTITY_COMPARE
+    )
 
     # Whether the communication between traits and context is currently active
     # or not.

--- a/codetools/execution/async_executing_context.py
+++ b/codetools/execution/async_executing_context.py
@@ -14,7 +14,7 @@ from concurrent.futures import Executor, Future
 from concurrent.futures import ThreadPoolExecutor
 
 from traits.api import (Instance, Dict, Event, Code, Any, on_trait_change,
-        Bool, Undefined, Supports)
+        Bool, Undefined, Supports, OBJECT_IDENTITY_COMPARE)
 
 from codetools.contexts.data_context import DataContext
 from .executing_context import ExecutingContext
@@ -43,7 +43,7 @@ class AsyncExecutingContext(ExecutingContext):
 
     # The local execution namespace
     subcontext = Supports(IListenableContext, factory=DataContext,
-        rich_compare=False)
+        comparison_mode=OBJECT_IDENTITY_COMPARE)
 
     # Fired when an exception occurs during execution.
     # Carries the exception.

--- a/codetools/execution/executing_context.py
+++ b/codetools/execution/executing_context.py
@@ -11,7 +11,7 @@ namespace.
 from __future__ import absolute_import
 
 from traits.api import (Bool, HasTraits, List, Str, Supports,
-    Undefined, adapt, provides, on_trait_change)
+    Undefined, adapt, provides, on_trait_change, OBJECT_IDENTITY_COMPARE)
 
 from codetools.contexts.data_context import DataContext
 from codetools.contexts.i_context import IContext, IListenableContext
@@ -51,7 +51,7 @@ class ExecutingContext(DataContext):
 
     # Override to provide a more specific requirement.
     subcontext = Supports(IListenableContext, factory=DataContext,
-        rich_compare=False)
+        comparison_mode=OBJECT_IDENTITY_COMPARE)
 
     executable = Supports(IExecutable, factory=CodeExecutable)
 


### PR DESCRIPTION
`rich_compare` has been deprecated since version 3.0.3 of traits and it's been replaced with the `comparison_mode` kwarg.

See PR https://github.com/enthought/traits/pull/598/ for more information.