### PR TITLE
Disable macOS builds on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,6 @@ matrix:
     - env: RUNTIME=2.7
     - env: RUNTIME=3.5
     - env: RUNTIME=3.6
-    - os: osx
-      env: RUNTIME=2.7
-    - os: osx
-      env: RUNTIME=3.5
-    - os: osx
-      env: RUNTIME=3.6
   fast_finish: true
 
 cache:
@@ -28,7 +22,6 @@ cache:
 before_install:
   - mkdir -p "${HOME}/.cache/download"
   - if [[ ${TRAVIS_OS_NAME} == 'linux' ]]; then ./install-edm-linux.sh; export PATH="${HOME}/edm/bin:${PATH}"; fi
-  - if [[ ${TRAVIS_OS_NAME} == 'osx' ]]; then ./install-edm-osx.sh; export PATH="${PATH}:/usr/local/bin"; fi
   - edm install -y wheel click coverage
 install:
   - edm run -- python etstool.py install --runtime=${RUNTIME} || exit


### PR DESCRIPTION
macOS minutes are expensive; remove macOS builds from the Travis CI configuration.