### PR TITLE
Replace use of apptools sweetpickle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ env:
 
 matrix:
   include:
-    - env: RUNTIME=2.7
-    - env: RUNTIME=3.5
     - env: RUNTIME=3.6
   fast_finish: true
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,8 +7,6 @@ environment:
 
   matrix:
 
-    - RUNTIME: '2.7'
-    - RUNTIME: '3.5'
     - RUNTIME: '3.6'
 
 matrix:

--- a/codetools/contexts/data_context.py
+++ b/codetools/contexts/data_context.py
@@ -14,8 +14,10 @@ from __future__ import absolute_import
 
 from collections import MutableMapping as DictMixin
 from contextlib import contextmanager
+import pickle
 
 from apptools import sweet_pickle
+from apptools.persistence.versioned_unpickler import VersionedUnpickler
 from traits.adaptation.api import (
     AdaptationOffer, get_global_adaptation_manager)
 from traits.api import (
@@ -191,7 +193,7 @@ class PersistableMixin(ABCHasTraits):
             file_object = open(file_or_path, 'rb')
 
         try:
-            data_context = sweet_pickle.load(file_object)
+            data_context = VersionedUnpickler(file_object).load()
         finally:
             if should_close:
                 file_object.close()
@@ -224,7 +226,7 @@ class PersistableMixin(ABCHasTraits):
             for item in self.keys():
                 if isinstance(self[item], tuple(NonPickleable)):
                     del self[item]
-            sweet_pickle.dump(self, file_object, 1)
+            pickle.dump(self, file_object, 1)
         finally:
             if should_close:
                 file_object.close()

--- a/codetools/contexts/data_context.py
+++ b/codetools/contexts/data_context.py
@@ -16,7 +16,6 @@ from collections import MutableMapping as DictMixin
 from contextlib import contextmanager
 import pickle
 
-from apptools import sweet_pickle
 from apptools.persistence.versioned_unpickler import VersionedUnpickler
 from traits.adaptation.api import (
     AdaptationOffer, get_global_adaptation_manager)

--- a/etstool.py
+++ b/etstool.py
@@ -103,7 +103,7 @@ python2_dependencies = {
     "mock",
 }
 
-supported_runtimes = ["2.7.13", "3.5.2", "3.6.0"]
+supported_runtimes = ["3.6"]
 
 @click.group()
 def cli():


### PR DESCRIPTION
Closes #45 

This PR replaces the use of `apptools` `sweetpickle` with `apptools.persistence` and `pickle` from the standard library (as was done in https://github.com/enthought/apptools/pull/199)

I believe the relevant code is covered by tests (e.g. https://github.com/enthought/codetools/blob/aa0d470c8a32cda785723b6ad0ccdf53e069437f/codetools/contexts/tests/data_context_test_case.py#L28-L43) , and running the test suite locally, tests all still passed.
As a sanity check it would be good to test with an application that depends on codetools `DataContext` 