### PR TITLE
Bump version for continued development (4.5.X)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup, find_packages
 
 
 MAJOR = 4
-MINOR = 4
+MINOR = 5
 MICRO = 0
 
 IS_RELEASED = False


### PR DESCRIPTION
This PR simply bumps the version number in setup.py for continued development in advance of the 4.4.0 minor release.