### PR TITLE
Fix bad expectations about unicode->unicode roundtripping in HDF5

### DIFF
--- a/codetools/contexts/tests/hdf5_context_test_case.py
+++ b/codetools/contexts/tests/hdf5_context_test_case.py
@@ -33,7 +33,7 @@ def create_sample_hdf5_file(filename):
     group2 = fileh.create_group(root, "group2")
 
     # Now, create an array in root group
-    array1 = fileh.create_array(root, "array1", ["string", "array"], "String array")
+    array1 = fileh.create_array(root, "array1", [b"string", b"array"], "String array")
     # Create 2 new tables in group1
     table1 = fileh.create_table(group1, "table1", Particle)
     table2 = fileh.create_table("/group2", "table2", Particle)
@@ -89,7 +89,7 @@ class Hdf5ContextTest(unittest.TestCase):
                               path=['root', 'root.group1', 'root.group2'])
             array1 = context['array1']
             assert_equal( len(array1), 2)
-            assert_equal( array1, ['string', 'array'])
+            assert_equal( array1, [b'string', b'array'])
             assert_equal(context.location('array1'), 'root')
 
     def test_get_array2(self):

--- a/etstool.py
+++ b/etstool.py
@@ -91,6 +91,7 @@ common_dependencies = {
     "numpy",
     "pillow",
     "pyface",
+    "pytables",
     "scimath",
     "Sphinx",
     "traits",


### PR DESCRIPTION
This PR fixes a test that fails when PyTables is installed into the test environment. It also adds PyTables to the development environment, so that this test is exercised by the CI.

Note: this PR doesn't even attempt to make sensible tests for what happens when a (Unicode) string array is stored and retrieved, but wimps out and simply tests a list of bytestrings. Unicode handling is a mess, both at PyTables level and at HDF5 level. See for example https://github.com/PyTables/PyTables/issues/499.

Fixes #42 
