### PR TITLE
Bump major version for next release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,8 @@ import sys
 from setuptools import setup, find_packages
 
 
-MAJOR = 4
-MINOR = 5
+MAJOR = 5
+MINOR = 0
 MICRO = 0
 
 IS_RELEASED = False


### PR DESCRIPTION
PR #58 (and possibly some others) warrants a major version bump. This PR updates the version number in `setup.py` to reflect that the master branch is now targeting version 5.0 rather than version 4.5.